### PR TITLE
feat: 사용자 참여 상태 관리 및 통계 필터링 기능 구현

### DIFF
--- a/src/main/java/shop/genieus/study/commons/provider/UserProvider.java
+++ b/src/main/java/shop/genieus/study/commons/provider/UserProvider.java
@@ -13,4 +13,6 @@ public interface UserProvider {
   UserSettingHistoryInfo getEffectiveSettingsByDate(Long userId, LocalDate date);
 
   List<UserInfo> getAllActiveUsers();
+
+  List<UserInfo> getAllParticipatingUsers();
 }

--- a/src/main/java/shop/genieus/study/commons/provider/dto/UserInfo.java
+++ b/src/main/java/shop/genieus/study/commons/provider/dto/UserInfo.java
@@ -1,5 +1,6 @@
 package shop.genieus.study.commons.provider.dto;
 
+
 import java.time.LocalTime;
 
 public record UserInfo(
@@ -10,4 +11,5 @@ public record UserInfo(
     String roleName,
     LocalTime desiredCheckInTime,
     Integer desiredCoreTime,
-    Boolean isActive) {}
+    Boolean isActive,
+    String participationStatus) {}

--- a/src/main/java/shop/genieus/study/domains/auth/presentation/config/SecurityConfig.java
+++ b/src/main/java/shop/genieus/study/domains/auth/presentation/config/SecurityConfig.java
@@ -65,6 +65,8 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.GET, "/users/check-nickname", "/users/check-email")
                 .permitAll()
                 // any request
+                .requestMatchers("/admin/**")
+                .hasRole("ADMIN")
                 .anyRequest()
                 .authenticated());
 

--- a/src/main/java/shop/genieus/study/domains/notification/application/DailyStatisticsService.java
+++ b/src/main/java/shop/genieus/study/domains/notification/application/DailyStatisticsService.java
@@ -38,15 +38,15 @@ public class DailyStatisticsService {
     log.info("일일 통계 수집 시작: {}", yesterday);
 
     try {
-      List<UserInfo> activeUsers = userProvider.getAllActiveUsers();
-      if (activeUsers.isEmpty()) {
-        log.info("활성 사용자가 없어 통계 생성을 건너뜁니다.");
+      List<UserInfo> participatingUsers = userProvider.getAllParticipatingUsers();
+      if (participatingUsers.isEmpty()) {
+        log.info("통계에 포함될 활성 참여자가 없어 통계 생성을 건너뜁니다.");
         return;
       }
 
       Map<Long, String> userNicknameMap = new HashMap<>();
       List<Long> userIds = new ArrayList<>();
-      for (UserInfo userInfo : activeUsers) {
+      for (UserInfo userInfo : participatingUsers) {
         userNicknameMap.put(userInfo.id(), userInfo.nickname());
         userIds.add(userInfo.id());
       }

--- a/src/main/java/shop/genieus/study/domains/user/application/UserCommandService.java
+++ b/src/main/java/shop/genieus/study/domains/user/application/UserCommandService.java
@@ -14,6 +14,7 @@ import shop.genieus.study.domains.user.application.repository.UserSettingHistory
 import shop.genieus.study.domains.user.domain.entity.User;
 import shop.genieus.study.domains.user.domain.entity.UserSettingHistory;
 import shop.genieus.study.domains.user.domain.exception.UserValidationException;
+import shop.genieus.study.domains.user.domain.vo.ParticipationStatus;
 import shop.genieus.study.domains.user.domain.vo.UserSettings;
 
 @Slf4j
@@ -49,7 +50,12 @@ public class UserCommandService {
 
     LocalDate today = dateTimeProvider.getCurrentDate();
     deactivateCurrentHistory(userId, today);
-    createNewSettingHistory(userId, today, newCheckInTime, newCoreTime);
+    createNewSettingHistory(
+        userId,
+        today,
+        newCheckInTime,
+        newCoreTime,
+        user.getCurrentSettings().getParticipationStatus());
 
     repository.save(user);
 
@@ -67,7 +73,11 @@ public class UserCommandService {
 
     UserSettingHistory initialHistory =
         UserSettingHistory.create(
-            user.getId(), today, settings.getDesiredCheckInTime(), settings.getDesiredCoreTime());
+            user.getId(),
+            today,
+            settings.getDesiredCheckInTime(),
+            settings.getDesiredCoreTime(),
+            settings.getParticipationStatus());
 
     settingHistoryRepository.save(initialHistory);
 
@@ -88,9 +98,14 @@ public class UserCommandService {
   }
 
   private void createNewSettingHistory(
-      Long userId, LocalDate effectiveDate, LocalTime checkInTime, int coreTime) {
+      Long userId,
+      LocalDate effectiveDate,
+      LocalTime checkInTime,
+      int coreTime,
+      ParticipationStatus participationStatus) {
     UserSettingHistory newHistory =
-        UserSettingHistory.create(userId, effectiveDate, checkInTime, coreTime);
+        UserSettingHistory.create(
+            userId, effectiveDate, checkInTime, coreTime, participationStatus);
 
     settingHistoryRepository.save(newHistory);
 

--- a/src/main/java/shop/genieus/study/domains/user/application/UserCommandService.java
+++ b/src/main/java/shop/genieus/study/domains/user/application/UserCommandService.java
@@ -8,11 +8,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import shop.genieus.study.commons.provider.DateTimeProvider;
 import shop.genieus.study.domains.user.application.dto.info.SignupUserInfo;
+import shop.genieus.study.domains.user.application.dto.info.UpdateParticipationStatusInfo;
 import shop.genieus.study.domains.user.application.dto.info.UpdateUserSettingInfo;
 import shop.genieus.study.domains.user.application.repository.UserRepository;
-import shop.genieus.study.domains.user.application.repository.UserSettingHistoryRepository;
 import shop.genieus.study.domains.user.domain.entity.User;
-import shop.genieus.study.domains.user.domain.entity.UserSettingHistory;
 import shop.genieus.study.domains.user.domain.exception.UserValidationException;
 import shop.genieus.study.domains.user.domain.vo.ParticipationStatus;
 import shop.genieus.study.domains.user.domain.vo.UserSettings;
@@ -23,7 +22,7 @@ import shop.genieus.study.domains.user.domain.vo.UserSettings;
 @RequiredArgsConstructor
 public class UserCommandService {
   private final UserRepository repository;
-  private final UserSettingHistoryRepository settingHistoryRepository;
+  private final UserSettingHistoryCommandService historyCommandService;
   private final PasswordEncryptionService encryptionService;
   private final DateTimeProvider dateTimeProvider;
 
@@ -35,7 +34,8 @@ public class UserCommandService {
         repository.save(
             User.create(info.email(), info.password(), encryptionService, info.nickname()));
 
-    createInitialSettingHistory(saved);
+    LocalDate today = dateTimeProvider.getCurrentDate();
+    historyCommandService.createInitialSettingHistory(saved, today);
 
     return saved;
   }
@@ -46,16 +46,13 @@ public class UserCommandService {
 
     LocalTime newCheckInTime = info.newCheckInTime();
     int newCoreTime = info.newCoreTime();
-    user.updateSettings(newCheckInTime, newCoreTime);
+    ParticipationStatus currentStatus = user.getCurrentSettings().getParticipationStatus();
+
+    user.updateSettings(newCheckInTime, newCoreTime, currentStatus);
 
     LocalDate today = dateTimeProvider.getCurrentDate();
-    deactivateCurrentHistory(userId, today);
-    createNewSettingHistory(
-        userId,
-        today,
-        newCheckInTime,
-        newCoreTime,
-        user.getCurrentSettings().getParticipationStatus());
+    historyCommandService.updateSettingHistory(
+        userId, today, newCheckInTime, newCoreTime, currentStatus);
 
     repository.save(user);
 
@@ -63,58 +60,44 @@ public class UserCommandService {
         "사용자 설정 변경: userId={}, checkInTime={}, coreTime={}", userId, newCheckInTime, newCoreTime);
   }
 
+  public void updateParticipationStatus(UpdateParticipationStatusInfo info) {
+    Long adminUserId = info.adminUserId();
+    Long targetUserId = info.targetUserId();
+    ParticipationStatus newStatus = info.participationStatus();
+    String reason = info.reason();
+
+    User targetUser = findById(targetUserId);
+    UserSettings currentSettings = targetUser.getCurrentSettings();
+    ParticipationStatus currentStatus = currentSettings.getParticipationStatus();
+
+    if (currentStatus == newStatus) {
+      throw UserValidationException.sameParticipationStatus();
+    }
+
+    targetUser.updateSettings(
+        currentSettings.getDesiredCheckInTime(), currentSettings.getDesiredCoreTime(), newStatus);
+
+    LocalDate today = dateTimeProvider.getCurrentDate();
+    historyCommandService.updateSettingHistory(
+        targetUserId,
+        today,
+        currentSettings.getDesiredCheckInTime(),
+        currentSettings.getDesiredCoreTime(),
+        newStatus);
+
+    repository.save(targetUser);
+
+    log.info(
+        "참여 상태 변경: adminUserId={}, targetUserId={}, {} -> {}, reason='{}'",
+        adminUserId,
+        targetUserId,
+        currentStatus,
+        newStatus,
+        reason);
+  }
+
   private User findById(Long userId) {
     return repository.findById(userId);
-  }
-
-  private void createInitialSettingHistory(User user) {
-    UserSettings settings = user.getCurrentSettings();
-    LocalDate today = dateTimeProvider.getCurrentDate();
-
-    UserSettingHistory initialHistory =
-        UserSettingHistory.create(
-            user.getId(),
-            today,
-            settings.getDesiredCheckInTime(),
-            settings.getDesiredCoreTime(),
-            settings.getParticipationStatus());
-
-    settingHistoryRepository.save(initialHistory);
-
-    log.info("초기 설정 이력 생성: userId={}", user.getId());
-  }
-
-  private void deactivateCurrentHistory(Long userId, LocalDate effectiveDate) {
-    UserSettingHistory history = settingHistoryRepository.findCurrentActiveSettings(userId);
-
-    history.deactivate(effectiveDate);
-    settingHistoryRepository.save(history);
-
-    log.info(
-        "기존 설정 이력 비활성화: userId={}, historyId={}, effectiveToDate={}",
-        userId,
-        history.getId(),
-        history.getEffectiveToDate());
-  }
-
-  private void createNewSettingHistory(
-      Long userId,
-      LocalDate effectiveDate,
-      LocalTime checkInTime,
-      int coreTime,
-      ParticipationStatus participationStatus) {
-    UserSettingHistory newHistory =
-        UserSettingHistory.create(
-            userId, effectiveDate, checkInTime, coreTime, participationStatus);
-
-    settingHistoryRepository.save(newHistory);
-
-    log.info(
-        "새 설정 이력 생성: userId={}, effectiveFromDate={}, checkInTime={}, coreTime={}",
-        userId,
-        effectiveDate,
-        checkInTime,
-        coreTime);
   }
 
   private void isSamePasswordAndPasswordConfirm(SignupUserInfo info) {

--- a/src/main/java/shop/genieus/study/domains/user/application/UserQueryService.java
+++ b/src/main/java/shop/genieus/study/domains/user/application/UserQueryService.java
@@ -72,10 +72,15 @@ public class UserQueryService implements UserProvider {
   }
 
   @Override
-  @Transactional(readOnly = true)
   public List<UserInfo> getAllActiveUsers() {
-    List<User> activeUsers = repository.findAllActiveUsers(); // JPA Repository에 추가 필요
+    List<User> activeUsers = repository.findAllActiveUsers();
     return activeUsers.stream().map(au -> mapper.from(au)).collect(Collectors.toList());
+  }
+
+  @Override
+  public List<UserInfo> getAllParticipatingUsers() {
+    List<User> participatingUsers = repository.findAllParticipatingUsers();
+    return participatingUsers.stream().map(mapper::from).collect(Collectors.toList());
   }
 
   private User findById(Long userId) {

--- a/src/main/java/shop/genieus/study/domains/user/application/UserSettingHistoryCommandService.java
+++ b/src/main/java/shop/genieus/study/domains/user/application/UserSettingHistoryCommandService.java
@@ -1,0 +1,67 @@
+package shop.genieus.study.domains.user.application;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import shop.genieus.study.domains.user.application.repository.UserSettingHistoryRepository;
+import shop.genieus.study.domains.user.domain.entity.User;
+import shop.genieus.study.domains.user.domain.entity.UserSettingHistory;
+import shop.genieus.study.domains.user.domain.vo.ParticipationStatus;
+import shop.genieus.study.domains.user.domain.vo.UserSettings;
+
+@Slf4j
+@Service
+@Transactional(readOnly = false)
+@RequiredArgsConstructor
+public class UserSettingHistoryCommandService {
+  private final UserSettingHistoryRepository settingHistoryRepository;
+
+  public void createInitialSettingHistory(User user, LocalDate today) {
+    UserSettings settings = user.getCurrentSettings();
+    createNewSettingHistory(
+        user.getId(),
+        today,
+        settings.getDesiredCheckInTime(),
+        settings.getDesiredCoreTime(),
+        settings.getParticipationStatus());
+
+    log.info("초기 설정 이력 생성: userId={}", user.getId());
+  }
+
+  public void updateSettingHistory(
+      Long userId,
+      LocalDate effectiveDate,
+      LocalTime checkInTime,
+      int coreTime,
+      ParticipationStatus participationStatus) {
+
+    deactivateCurrentHistory(userId, effectiveDate);
+    createNewSettingHistory(userId, effectiveDate, checkInTime, coreTime, participationStatus);
+  }
+
+  private void deactivateCurrentHistory(Long userId, LocalDate effectiveDate) {
+    UserSettingHistory history = settingHistoryRepository.findCurrentActiveSettings(userId);
+    history.deactivate(effectiveDate);
+    settingHistoryRepository.save(history);
+
+    log.info("기존 설정 이력 비활성화: userId={}, historyId={}", userId, history.getId());
+  }
+
+  private void createNewSettingHistory(
+      Long userId,
+      LocalDate effectiveDate,
+      LocalTime checkInTime,
+      int coreTime,
+      ParticipationStatus participationStatus) {
+
+    UserSettingHistory newHistory =
+        UserSettingHistory.create(
+            userId, effectiveDate, checkInTime, coreTime, participationStatus);
+    settingHistoryRepository.save(newHistory);
+
+    log.info("새 설정 이력 생성: userId={}, effectiveFromDate={}", userId, effectiveDate);
+  }
+}

--- a/src/main/java/shop/genieus/study/domains/user/application/dto/info/UpdateParticipationStatusInfo.java
+++ b/src/main/java/shop/genieus/study/domains/user/application/dto/info/UpdateParticipationStatusInfo.java
@@ -1,0 +1,6 @@
+package shop.genieus.study.domains.user.application.dto.info;
+
+import shop.genieus.study.domains.user.domain.vo.ParticipationStatus;
+
+public record UpdateParticipationStatusInfo(
+    Long adminUserId, Long targetUserId, ParticipationStatus participationStatus, String reason) {}

--- a/src/main/java/shop/genieus/study/domains/user/application/mapper/UserMapper.java
+++ b/src/main/java/shop/genieus/study/domains/user/application/mapper/UserMapper.java
@@ -23,7 +23,8 @@ public class UserMapper {
         getValueOrNull(user.getRole(), Enum::name),
         getValueOrNull(currentUserSettings, UserSettings::getDesiredCheckInTime),
         getValueOrNull(currentUserSettings, UserSettings::getDesiredCoreTime),
-        user.getIsActive());
+        user.getIsActive(),
+        currentUserSettings.getParticipationStatus().name());
   }
 
   public UserSettingHistoryInfo from(UserSettingHistory history) {

--- a/src/main/java/shop/genieus/study/domains/user/application/repository/UserRepository.java
+++ b/src/main/java/shop/genieus/study/domains/user/application/repository/UserRepository.java
@@ -15,4 +15,6 @@ public interface UserRepository {
   User findById(Long userId);
 
   List<User> findAllActiveUsers();
+
+  List<User> findAllParticipatingUsers();
 }

--- a/src/main/java/shop/genieus/study/domains/user/domain/entity/User.java
+++ b/src/main/java/shop/genieus/study/domains/user/domain/entity/User.java
@@ -76,13 +76,13 @@ public class User extends BaseEntity {
     return this.password.matches(plainPassword, passwordEncryptionService);
   }
 
-  public void updateSettings(LocalTime newCheckInTime, int newCoreTime) {
-    if (currentSettings.isSameAs(newCheckInTime, newCoreTime)) {
+  public void updateSettings(
+      LocalTime newCheckInTime, int newCoreTime, ParticipationStatus newParticipationStatus) {
+    if (currentSettings.isSameAs(newCheckInTime, newCoreTime, newParticipationStatus)) {
       throw UserValidationException.sameSetting();
     }
 
-    UserSettings newSettings =
-        UserSettings.of(newCheckInTime, newCoreTime, currentSettings.getParticipationStatus());
+    UserSettings newSettings = UserSettings.of(newCheckInTime, newCoreTime, newParticipationStatus);
     this.currentSettings = newSettings;
   }
 

--- a/src/main/java/shop/genieus/study/domains/user/domain/entity/User.java
+++ b/src/main/java/shop/genieus/study/domains/user/domain/entity/User.java
@@ -81,7 +81,8 @@ public class User extends BaseEntity {
       throw UserValidationException.sameSetting();
     }
 
-    UserSettings newSettings = UserSettings.of(newCheckInTime, newCoreTime);
+    UserSettings newSettings =
+        UserSettings.of(newCheckInTime, newCoreTime, currentSettings.getParticipationStatus());
     this.currentSettings = newSettings;
   }
 

--- a/src/main/java/shop/genieus/study/domains/user/domain/entity/UserSettingHistory.java
+++ b/src/main/java/shop/genieus/study/domains/user/domain/entity/UserSettingHistory.java
@@ -16,11 +16,6 @@ import shop.genieus.study.domains.user.domain.vo.ParticipationStatus;
     indexes = {
       @Index(name = "idx_user_effective_date", columnList = "userId, effectiveFromDate"),
       @Index(name = "idx_user_active", columnList = "userId, isActive")
-    },
-    uniqueConstraints = {
-      @UniqueConstraint(
-          name = "uk_user_effective_date",
-          columnNames = {"userId", "effectiveFromDate"})
     })
 @Builder(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)

--- a/src/main/java/shop/genieus/study/domains/user/domain/entity/UserSettingHistory.java
+++ b/src/main/java/shop/genieus/study/domains/user/domain/entity/UserSettingHistory.java
@@ -6,6 +6,7 @@ import java.time.LocalTime;
 import lombok.*;
 import org.hibernate.annotations.Comment;
 import shop.genieus.study.commons.jpa.BaseEntity;
+import shop.genieus.study.domains.user.domain.vo.ParticipationStatus;
 
 @Entity
 @Getter
@@ -54,14 +55,24 @@ public class UserSettingHistory extends BaseEntity {
   @Column(nullable = false)
   private boolean isActive;
 
+  @Comment("참여 상태")
+  @Column(nullable = false)
+  @Enumerated(EnumType.STRING)
+  private ParticipationStatus participationStatus;
+
   public static UserSettingHistory create(
-      Long userId, LocalDate effectiveFromDate, LocalTime desiredCheckInTime, int desiredCoreTime) {
+      Long userId,
+      LocalDate effectiveFromDate,
+      LocalTime desiredCheckInTime,
+      int desiredCoreTime,
+      ParticipationStatus participationStatus) {
 
     return UserSettingHistory.builder()
         .userId(userId)
         .effectiveFromDate(effectiveFromDate)
         .desiredCheckInTime(desiredCheckInTime)
         .desiredCoreTime(desiredCoreTime)
+        .participationStatus(participationStatus)
         .isActive(true)
         .build();
   }

--- a/src/main/java/shop/genieus/study/domains/user/domain/exception/UserValidationException.java
+++ b/src/main/java/shop/genieus/study/domains/user/domain/exception/UserValidationException.java
@@ -91,4 +91,8 @@ public class UserValidationException extends ValidationException {
   public static UserValidationException sameSetting() {
     return new UserValidationException("기존 설정과 동일합니다.");
   }
+
+  public static UserValidationException requiredParticipationStatus() {
+    return new UserValidationException("참여 상태는 필수입니다.");
+  }
 }

--- a/src/main/java/shop/genieus/study/domains/user/domain/exception/UserValidationException.java
+++ b/src/main/java/shop/genieus/study/domains/user/domain/exception/UserValidationException.java
@@ -95,4 +95,8 @@ public class UserValidationException extends ValidationException {
   public static UserValidationException requiredParticipationStatus() {
     return new UserValidationException("참여 상태는 필수입니다.");
   }
+
+  public static UserValidationException sameParticipationStatus() {
+    return new UserValidationException("기존 참여 상태와 동일합니다.");
+  }
 }

--- a/src/main/java/shop/genieus/study/domains/user/domain/vo/ParticipationStatus.java
+++ b/src/main/java/shop/genieus/study/domains/user/domain/vo/ParticipationStatus.java
@@ -1,0 +1,15 @@
+package shop.genieus.study.domains.user.domain.vo;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ParticipationStatus {
+  ACTIVE("활성 참여"),
+  INACTIVE("비활성 참여"),
+  TEMPORARY_LEAVE("일시 휴가"),
+  ;
+
+  private final String description;
+}

--- a/src/main/java/shop/genieus/study/domains/user/domain/vo/UserSettings.java
+++ b/src/main/java/shop/genieus/study/domains/user/domain/vo/UserSettings.java
@@ -78,8 +78,11 @@ public class UserSettings {
     }
   }
 
-  public boolean isSameAs(LocalTime checkInTime, int coreTime) {
-    return this.desiredCheckInTime.equals(checkInTime) && this.desiredCoreTime == coreTime;
+  public boolean isSameAs(
+      LocalTime checkInTime, int coreTime, ParticipationStatus participationStatus) {
+    return this.desiredCheckInTime.equals(checkInTime)
+        && this.desiredCoreTime == coreTime
+        && this.participationStatus == participationStatus;
   }
 
   @Override

--- a/src/main/java/shop/genieus/study/domains/user/domain/vo/UserSettings.java
+++ b/src/main/java/shop/genieus/study/domains/user/domain/vo/UserSettings.java
@@ -2,6 +2,8 @@ package shop.genieus.study.domains.user.domain.vo;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import java.time.LocalTime;
 import java.util.Objects;
 import lombok.AccessLevel;
@@ -27,20 +29,32 @@ public class UserSettings {
   @Column(name = "desired_core_time", nullable = false)
   private int desiredCoreTime;
 
-  private UserSettings(LocalTime desiredCheckInTime, int desiredCoreTime) {
+  @Comment("참여 상태")
+  @Column(
+      name = "participation_status",
+      nullable = false,
+      columnDefinition = "VARCHAR(50) DEFAULT 'ACTIVE'")
+  @Enumerated(EnumType.STRING)
+  private ParticipationStatus participationStatus = ParticipationStatus.ACTIVE;
+
+  private UserSettings(
+      LocalTime desiredCheckInTime, int desiredCoreTime, ParticipationStatus participationStatus) {
     validateCheckInTime(desiredCheckInTime);
     validateCoreTime(desiredCoreTime);
+    validateParticipationStatus(participationStatus);
 
     this.desiredCheckInTime = desiredCheckInTime;
     this.desiredCoreTime = desiredCoreTime;
+    this.participationStatus = participationStatus;
   }
 
-  public static UserSettings of(LocalTime desiredCheckInTime, int desiredCoreTime) {
-    return new UserSettings(desiredCheckInTime, desiredCoreTime);
+  public static UserSettings of(
+      LocalTime desiredCheckInTime, int desiredCoreTime, ParticipationStatus participationStatus) {
+    return new UserSettings(desiredCheckInTime, desiredCoreTime, participationStatus);
   }
 
   public static UserSettings defaultSettings() {
-    return new UserSettings(LocalTime.of(9, 0), 240);
+    return new UserSettings(LocalTime.of(9, 0), 240, ParticipationStatus.ACTIVE);
   }
 
   private static void validateCheckInTime(LocalTime checkInTime) {
@@ -55,6 +69,12 @@ public class UserSettings {
   private static void validateCoreTime(int coreTime) {
     if (coreTime < MIN_CORE_TIME || coreTime > MAX_CORE_TIME) {
       throw UserValidationException.invalidCoreTimeRange(MIN_CORE_TIME, MAX_CORE_TIME);
+    }
+  }
+
+  private static void validateParticipationStatus(ParticipationStatus participationStatus) {
+    if (participationStatus == null) {
+      throw UserValidationException.requiredParticipationStatus();
     }
   }
 

--- a/src/main/java/shop/genieus/study/domains/user/infrastructure/persistence/UserRepositoryImpl.java
+++ b/src/main/java/shop/genieus/study/domains/user/infrastructure/persistence/UserRepositoryImpl.java
@@ -47,4 +47,9 @@ public class UserRepositoryImpl implements UserRepository {
   public List<User> findAllActiveUsers() {
     return jpaRepository.findAllActiveUsers();
   }
+
+  @Override
+  public List<User> findAllParticipatingUsers() {
+    return jpaRepository.findAllParticipatingUsers();
+  }
 }

--- a/src/main/java/shop/genieus/study/domains/user/infrastructure/persistence/repository/UserJpaRepository.java
+++ b/src/main/java/shop/genieus/study/domains/user/infrastructure/persistence/repository/UserJpaRepository.java
@@ -17,4 +17,8 @@ public interface UserJpaRepository extends JpaRepository<User, Long> {
 
   @Query("SELECT u FROM User u WHERE u.isActive = true AND u.status = 'APPROVED'")
   List<User> findAllActiveUsers();
+
+  @Query(
+      "SELECT u FROM User u WHERE u.isActive = true AND u.status = 'APPROVED' AND u.currentSettings.participationStatus = 'ACTIVE'")
+  List<User> findAllParticipatingUsers();
 }

--- a/src/main/java/shop/genieus/study/domains/user/presentation/AdminUserController.java
+++ b/src/main/java/shop/genieus/study/domains/user/presentation/AdminUserController.java
@@ -1,0 +1,30 @@
+package shop.genieus.study.domains.user.presentation;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+import shop.genieus.study.domains.auth.presentation.annotation.AuthPrincipal;
+import shop.genieus.study.domains.auth.presentation.dto.CustomPrincipal;
+import shop.genieus.study.domains.user.application.UserCommandService;
+import shop.genieus.study.domains.user.presentation.dto.request.UpdateParticipationStatusRequest;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/users")
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminUserController {
+  private final UserCommandService userCommandService;
+
+  @PatchMapping("/{userId}/participation-status")
+  public ResponseEntity<Void> updateParticipationStatus(
+      @AuthPrincipal CustomPrincipal principal,
+      @PathVariable Long userId,
+      @RequestBody @Valid UpdateParticipationStatusRequest request) {
+
+    userCommandService.updateParticipationStatus(request.toInfo(principal.id(), userId));
+
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/src/main/java/shop/genieus/study/domains/user/presentation/dto/request/UpdateParticipationStatusRequest.java
+++ b/src/main/java/shop/genieus/study/domains/user/presentation/dto/request/UpdateParticipationStatusRequest.java
@@ -1,0 +1,14 @@
+package shop.genieus.study.domains.user.presentation.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import shop.genieus.study.domains.user.application.dto.info.UpdateParticipationStatusInfo;
+import shop.genieus.study.domains.user.domain.vo.ParticipationStatus;
+
+public record UpdateParticipationStatusRequest(
+    @NotNull(message = "참여 상태는 필수입니다.") ParticipationStatus participationStatus, String reason) {
+
+  public UpdateParticipationStatusInfo toInfo(Long adminUserId, Long targetUserId) {
+    return new UpdateParticipationStatusInfo(
+        adminUserId, targetUserId, participationStatus, reason);
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -51,4 +51,4 @@ scheduler:
   notification:
     check-in-cron: "0 50 8 * * 1-5"       # 매일 08:50에 출석 알림 (평일)
     check-out-cron: "0 0 16 * * 1-5"      # 매일 16:00에 코어 시간 종료 알림 (평일)
-    daily-statistics-cron: "0 55 8 * * 2-6	"  # 화~토 자정 (전날 통계)
+    daily-statistics-cron: "0 0 0 * * 2-6	"  # 화~토 자정 (전날 통계)


### PR DESCRIPTION
## 개요
스터디원의 참여 상태를 관리하여 통계 집계 시 비참여자를 제외하고, 관리자가 스터디원의 참여 상태를 제어할 수 있는 기능을 추가했습니다.

## 📝 작업 내용
### 변경 사항

**1. 도메인 모델 확장**
- `ParticipationStatus` Enum 추가 (ACTIVE, TEMPORARY_LEAVE, INACTIVE)
- `UserSettings` VO에 `participationStatus` 필드 추가 및 관련 메서드 구현
- `UserSettingHistory` Entity에 참여 상태 필드 추가
- `User` Entity의 설정 업데이트 메서드 확장

**2. 데이터베이스 스키마 변경**
- `g_users` 테이블에 `participation_status` 컬럼 추가 (기본값: 'ACTIVE')
- `g_user_settings_histories` 테이블에 `participation_status` 컬럼 추가
- `uk_user_effective_date` 제약조건 삭제 (하루 내 다중 변경 지원)

**3. API 개발**
- 관리자 전용 참여 상태 변경 API (`PATCH /admin/users/{userId}/participation-status`) 추가
- `@PreAuthorize("hasRole('ADMIN')")` 권한 검증 적용


**4. 비즈니스 로직 개선**
- `UserRepository.findAllParticipatingUsers()` 메서드 추가로 쿼리 레벨 필터링
- `DailyStatisticsService`에서 ACTIVE 상태 사용자만 통계에 포함
- `UserSettingHistoryCommandService` 분리로 설정 이력 관리 책임 분리

**5. DTO 및 Provider 확장**
- `UpdateParticipationStatusInfo`, `UpdateParticipationStatusRequest` DTO 추가
- `UserInfo` DTO에 `participationStatus` 필드 추가
- 관련 매퍼 클래스 업데이트

### 변경 이유

**문제점:**
- 기존 통계 시스템에서 모든 활성 사용자가 포함되어 일시적으로 참여하지 않는 스터디원도 통계에 반영됨
- 관리자가 스터디원의 참여 상태를 유연하게 관리할 수 있는 방법 부족
- 휴가, 개인 사정 등으로 인한 일시적 불참을 구분할 수 없음

**해결책:**
- 참여 상태 기반 권한 제어 시스템 도입
- 관리자 전용 API로 상태 관리

### 추가 설명

**참여 상태별 권한:**
- `ACTIVE`: 정상 참여 (출석, 도장 생성, 통계 포함)
- `TEMPORARY_LEAVE`: 일시 휴가 (로그인만 가능, 통계 제외)
- `INACTIVE`: 비활성 (로그인만 가능, 통계 제외)

## 💬리뷰 요구사항

#### #️⃣ 연관된 이슈
closed #36

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [x] 새로운 기능 추가
- [x] 코드 리팩토링

## ✅ Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.