### PR TITLE
feat: 학습 목표 관리 구현

### DIFF
--- a/src/main/java/shop/genieus/study/commons/exception/Domain.java
+++ b/src/main/java/shop/genieus/study/commons/exception/Domain.java
@@ -6,5 +6,6 @@ public enum Domain {
   STAMP,
   ATTENDANCE,
   NOTIFICATION,
+  LEARNING_GOAL,
   GLOBAL
 }

--- a/src/main/java/shop/genieus/study/domains/learninggoal/application/LearningGoalCommandService.java
+++ b/src/main/java/shop/genieus/study/domains/learninggoal/application/LearningGoalCommandService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import shop.genieus.study.commons.provider.DateTimeProvider;
 import shop.genieus.study.domains.learninggoal.application.dto.info.CreateLearningGoalInfo;
+import shop.genieus.study.domains.learninggoal.application.dto.info.DeleteLearningGoalInfo;
 import shop.genieus.study.domains.learninggoal.application.dto.info.ToggleLearningGoalInfo;
 import shop.genieus.study.domains.learninggoal.application.repository.LearningGoalRepository;
 import shop.genieus.study.domains.learninggoal.domain.entity.LearningGoal;
@@ -49,6 +50,17 @@ public class LearningGoalCommandService {
         updated.getIsCompleted());
 
     return updated;
+  }
+
+  public void deleteLearningGoal(DeleteLearningGoalInfo info) {
+    Long userId = info.userId();
+    Long goalId = info.goalId();
+
+    LearningGoal goal = repository.findById(goalId);
+    validateOwnership(goal, userId);
+    repository.delete(goal);
+
+    log.info("학습 목표 삭제: userId={}, goalId={}", userId, goalId);
   }
 
   private void validateOwnership(LearningGoal learningGoal, Long userId) {

--- a/src/main/java/shop/genieus/study/domains/learninggoal/application/LearningGoalCommandService.java
+++ b/src/main/java/shop/genieus/study/domains/learninggoal/application/LearningGoalCommandService.java
@@ -7,8 +7,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import shop.genieus.study.commons.provider.DateTimeProvider;
 import shop.genieus.study.domains.learninggoal.application.dto.info.CreateLearningGoalInfo;
+import shop.genieus.study.domains.learninggoal.application.dto.info.ToggleLearningGoalInfo;
 import shop.genieus.study.domains.learninggoal.application.repository.LearningGoalRepository;
 import shop.genieus.study.domains.learninggoal.domain.entity.LearningGoal;
+import shop.genieus.study.domains.learninggoal.domain.exception.LearningGoalBusinessException;
 
 @Slf4j
 @Service
@@ -31,5 +33,27 @@ public class LearningGoalCommandService {
         saved.getId());
 
     return saved;
+  }
+
+  public LearningGoal toggleLearningGoal(ToggleLearningGoalInfo info) {
+    LearningGoal learningGoal = repository.findById(info.goalId());
+    validateOwnership(learningGoal, info.userId());
+
+    learningGoal.toggleCompletion();
+    LearningGoal updated = repository.save(learningGoal);
+
+    log.info(
+        "학습 목표 완료 상태 변경: userId={}, goalId={}, completed={}",
+        updated.getUserId(),
+        updated.getId(),
+        updated.getIsCompleted());
+
+    return updated;
+  }
+
+  private void validateOwnership(LearningGoal learningGoal, Long userId) {
+    if (!learningGoal.isOwnedBy(userId)) {
+      throw LearningGoalBusinessException.noPermissionForGoal();
+    }
   }
 }

--- a/src/main/java/shop/genieus/study/domains/learninggoal/application/LearningGoalCommandService.java
+++ b/src/main/java/shop/genieus/study/domains/learninggoal/application/LearningGoalCommandService.java
@@ -1,0 +1,35 @@
+package shop.genieus.study.domains.learninggoal.application;
+
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import shop.genieus.study.commons.provider.DateTimeProvider;
+import shop.genieus.study.domains.learninggoal.application.dto.info.CreateLearningGoalInfo;
+import shop.genieus.study.domains.learninggoal.application.repository.LearningGoalRepository;
+import shop.genieus.study.domains.learninggoal.domain.entity.LearningGoal;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class LearningGoalCommandService {
+  private final LearningGoalRepository repository;
+  private final DateTimeProvider dateTimeProvider;
+
+  public LearningGoal createLearningGoal(CreateLearningGoalInfo info) {
+    LocalDate today = dateTimeProvider.getCurrentDate();
+    LearningGoal learningGoal =
+        LearningGoal.create(info.userId(), info.date(), info.content(), today);
+    LearningGoal saved = repository.save(learningGoal);
+
+    log.info(
+        "학습 목표 생성: userId={}, date={}, goalId={}",
+        saved.getUserId(),
+        saved.getDate(),
+        saved.getId());
+
+    return saved;
+  }
+}

--- a/src/main/java/shop/genieus/study/domains/learninggoal/application/LearningGoalQueryService.java
+++ b/src/main/java/shop/genieus/study/domains/learninggoal/application/LearningGoalQueryService.java
@@ -1,0 +1,40 @@
+package shop.genieus.study.domains.learninggoal.application;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import shop.genieus.study.commons.provider.DateTimeProvider;
+import shop.genieus.study.domains.learninggoal.application.dto.info.GetLearningGoalsInfo;
+import shop.genieus.study.domains.learninggoal.application.dto.result.LearningGoalListResult;
+import shop.genieus.study.domains.learninggoal.application.repository.LearningGoalRepository;
+import shop.genieus.study.domains.learninggoal.domain.entity.LearningGoal;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LearningGoalQueryService {
+
+  private final LearningGoalRepository repository;
+  private final DateTimeProvider dateTimeProvider;
+
+  public LearningGoalListResult getLearningGoals(GetLearningGoalsInfo info) {
+    Long userId = info.targetUserId();
+    LocalDate date = getCurrentDate(info.date());
+
+    List<LearningGoal> goals = repository.findByUserIdAndDate(userId, date);
+
+    log.debug("학습 목표 조회: userId={}, date={}, count={}", userId, date, goals.size());
+
+    return new LearningGoalListResult(
+        goals, userId, date, !goals.isEmpty() && goals.get(0).isOwnedBy(info.loginUserId()));
+  }
+
+  private LocalDate getCurrentDate(LocalDate date) {
+    return Objects.requireNonNullElse(date, dateTimeProvider.getCurrentDate());
+  }
+}

--- a/src/main/java/shop/genieus/study/domains/learninggoal/application/dto/info/CreateLearningGoalInfo.java
+++ b/src/main/java/shop/genieus/study/domains/learninggoal/application/dto/info/CreateLearningGoalInfo.java
@@ -1,0 +1,5 @@
+package shop.genieus.study.domains.learninggoal.application.dto.info;
+
+import java.time.LocalDate;
+
+public record CreateLearningGoalInfo(Long userId, LocalDate date, String content) {}

--- a/src/main/java/shop/genieus/study/domains/learninggoal/application/dto/info/DeleteLearningGoalInfo.java
+++ b/src/main/java/shop/genieus/study/domains/learninggoal/application/dto/info/DeleteLearningGoalInfo.java
@@ -1,0 +1,3 @@
+package shop.genieus.study.domains.learninggoal.application.dto.info;
+
+public record DeleteLearningGoalInfo(Long userId, Long goalId) {}

--- a/src/main/java/shop/genieus/study/domains/learninggoal/application/dto/info/GetLearningGoalsInfo.java
+++ b/src/main/java/shop/genieus/study/domains/learninggoal/application/dto/info/GetLearningGoalsInfo.java
@@ -1,0 +1,5 @@
+package shop.genieus.study.domains.learninggoal.application.dto.info;
+
+import java.time.LocalDate;
+
+public record GetLearningGoalsInfo(Long targetUserId, Long loginUserId, LocalDate date) {}

--- a/src/main/java/shop/genieus/study/domains/learninggoal/application/dto/info/ToggleLearningGoalInfo.java
+++ b/src/main/java/shop/genieus/study/domains/learninggoal/application/dto/info/ToggleLearningGoalInfo.java
@@ -1,0 +1,3 @@
+package shop.genieus.study.domains.learninggoal.application.dto.info;
+
+public record ToggleLearningGoalInfo(Long userId, Long goalId) {}

--- a/src/main/java/shop/genieus/study/domains/learninggoal/application/dto/result/LearningGoalListResult.java
+++ b/src/main/java/shop/genieus/study/domains/learninggoal/application/dto/result/LearningGoalListResult.java
@@ -1,0 +1,8 @@
+package shop.genieus.study.domains.learninggoal.application.dto.result;
+
+import java.time.LocalDate;
+import java.util.List;
+import shop.genieus.study.domains.learninggoal.domain.entity.LearningGoal;
+
+public record LearningGoalListResult(
+    List<LearningGoal> goals, Long userId, LocalDate date, boolean isOwner) {}

--- a/src/main/java/shop/genieus/study/domains/learninggoal/application/exception/LearningGoalNotFoundException.java
+++ b/src/main/java/shop/genieus/study/domains/learninggoal/application/exception/LearningGoalNotFoundException.java
@@ -1,0 +1,17 @@
+package shop.genieus.study.domains.learninggoal.application.exception;
+
+import lombok.Getter;
+import shop.genieus.study.commons.exception.Domain;
+import shop.genieus.study.commons.exception.NotFoundException;
+
+@Getter
+public class LearningGoalNotFoundException extends NotFoundException {
+
+  private LearningGoalNotFoundException(String message) {
+    super(message, Domain.LEARNING_GOAL);
+  }
+
+  public static LearningGoalNotFoundException create(Long id) {
+    return new LearningGoalNotFoundException("해당 학습 목표를 찾을 수 없습니다. ID: " + id);
+  }
+}

--- a/src/main/java/shop/genieus/study/domains/learninggoal/application/repository/LearningGoalRepository.java
+++ b/src/main/java/shop/genieus/study/domains/learninggoal/application/repository/LearningGoalRepository.java
@@ -6,4 +6,6 @@ import shop.genieus.study.domains.learninggoal.domain.entity.LearningGoal;
 
 public interface LearningGoalRepository {
   List<LearningGoal> findByUserIdAndDate(Long userId, LocalDate date);
+
+  LearningGoal save(LearningGoal learningGoal);
 }

--- a/src/main/java/shop/genieus/study/domains/learninggoal/application/repository/LearningGoalRepository.java
+++ b/src/main/java/shop/genieus/study/domains/learninggoal/application/repository/LearningGoalRepository.java
@@ -8,4 +8,6 @@ public interface LearningGoalRepository {
   List<LearningGoal> findByUserIdAndDate(Long userId, LocalDate date);
 
   LearningGoal save(LearningGoal learningGoal);
+
+  LearningGoal findById(Long goalId);
 }

--- a/src/main/java/shop/genieus/study/domains/learninggoal/application/repository/LearningGoalRepository.java
+++ b/src/main/java/shop/genieus/study/domains/learninggoal/application/repository/LearningGoalRepository.java
@@ -10,4 +10,6 @@ public interface LearningGoalRepository {
   LearningGoal save(LearningGoal learningGoal);
 
   LearningGoal findById(Long goalId);
+
+  void delete(LearningGoal goal);
 }

--- a/src/main/java/shop/genieus/study/domains/learninggoal/application/repository/LearningGoalRepository.java
+++ b/src/main/java/shop/genieus/study/domains/learninggoal/application/repository/LearningGoalRepository.java
@@ -1,0 +1,9 @@
+package shop.genieus.study.domains.learninggoal.application.repository;
+
+import java.time.LocalDate;
+import java.util.List;
+import shop.genieus.study.domains.learninggoal.domain.entity.LearningGoal;
+
+public interface LearningGoalRepository {
+  List<LearningGoal> findByUserIdAndDate(Long userId, LocalDate date);
+}

--- a/src/main/java/shop/genieus/study/domains/learninggoal/domain/entity/LearningGoal.java
+++ b/src/main/java/shop/genieus/study/domains/learninggoal/domain/entity/LearningGoal.java
@@ -1,0 +1,102 @@
+package shop.genieus.study.domains.learninggoal.domain.entity;
+
+import static org.springframework.util.StringUtils.hasText;
+
+import jakarta.persistence.*;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.*;
+import org.hibernate.annotations.Comment;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import shop.genieus.study.domains.learninggoal.domain.exception.LearningGoalValidationException;
+
+@Entity
+@Getter
+@Comment("학습 목표 테이블")
+@Table(
+    name = "g_learning_goals",
+    indexes = {
+      @Index(name = "idx_user_date", columnList = "userId, date"),
+      @Index(name = "idx_user_completed", columnList = "userId, isCompleted")
+    })
+@Builder(access = AccessLevel.PRIVATE)
+@EntityListeners(AuditingEntityListener.class)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LearningGoal {
+
+  private static final int MAX_CONTENT_LENGTH = 50;
+
+  @Id
+  @Comment("학습 목표 아이디")
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Comment("사용자 아이디")
+  @Column(nullable = false)
+  private Long userId;
+
+  @Comment("목표 날짜")
+  @Column(nullable = false)
+  private LocalDate date;
+
+  @Comment("목표 내용")
+  @Column(nullable = false, length = MAX_CONTENT_LENGTH)
+  private String content;
+
+  @Builder.Default
+  @Comment("완료 여부")
+  @Column(nullable = false)
+  private Boolean isCompleted = false;
+
+  @CreatedDate
+  @Comment("생성 일시")
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  public static LearningGoal create(
+      Long userId, LocalDate date, String content, LocalDate currentDate) {
+    validateDate(date, currentDate);
+    validateContent(content);
+
+    return LearningGoal.builder()
+        .userId(userId)
+        .date(date)
+        .content(content)
+        .isCompleted(false)
+        .build();
+  }
+
+  private static void validateDate(LocalDate date, LocalDate currentDate) {
+    if (date == null) {
+      throw LearningGoalValidationException.requiredDate();
+    }
+
+    if (!date.equals(currentDate)) {
+      throw LearningGoalValidationException.invalidDate();
+    }
+  }
+
+  private static void validateContent(String content) {
+    if (!hasText(content)) {
+      throw LearningGoalValidationException.requiredContent();
+    }
+
+    if (content.length() > MAX_CONTENT_LENGTH) {
+      throw LearningGoalValidationException.exceedsContentMaxLength(MAX_CONTENT_LENGTH);
+    }
+  }
+
+  public void toggleCompletion() {
+    this.isCompleted = !this.isCompleted;
+  }
+
+  public boolean isOwnedBy(Long userId) {
+    return this.userId.equals(userId);
+  }
+
+  public boolean isCompleted() {
+    return this.isCompleted;
+  }
+}

--- a/src/main/java/shop/genieus/study/domains/learninggoal/domain/entity/LearningGoal.java
+++ b/src/main/java/shop/genieus/study/domains/learninggoal/domain/entity/LearningGoal.java
@@ -8,6 +8,7 @@ import java.time.LocalDateTime;
 import lombok.*;
 import org.hibernate.annotations.Comment;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import shop.genieus.study.domains.learninggoal.domain.exception.LearningGoalValidationException;
 
@@ -54,6 +55,11 @@ public class LearningGoal {
   @Comment("생성 일시")
   @Column(name = "created_at", nullable = false, updatable = false)
   private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  @Column(name = "updated_at", insertable = false)
+  @Comment("수정 일시")
+  private LocalDateTime updatedAt;
 
   public static LearningGoal create(
       Long userId, LocalDate date, String content, LocalDate currentDate) {

--- a/src/main/java/shop/genieus/study/domains/learninggoal/domain/exception/LearningGoalBusinessException.java
+++ b/src/main/java/shop/genieus/study/domains/learninggoal/domain/exception/LearningGoalBusinessException.java
@@ -1,0 +1,17 @@
+package shop.genieus.study.domains.learninggoal.domain.exception;
+
+import lombok.Getter;
+import shop.genieus.study.commons.exception.BusinessException;
+import shop.genieus.study.commons.exception.Domain;
+
+@Getter
+public class LearningGoalBusinessException extends BusinessException {
+
+  private LearningGoalBusinessException(String message) {
+    super(message, Domain.LEARNING_GOAL);
+  }
+
+  public static LearningGoalBusinessException noPermissionForGoal() {
+    return new LearningGoalBusinessException("해당 학습 목표에 권한이 없습니다.");
+  }
+}

--- a/src/main/java/shop/genieus/study/domains/learninggoal/domain/exception/LearningGoalValidationException.java
+++ b/src/main/java/shop/genieus/study/domains/learninggoal/domain/exception/LearningGoalValidationException.java
@@ -1,0 +1,29 @@
+package shop.genieus.study.domains.learninggoal.domain.exception;
+
+import lombok.Getter;
+import shop.genieus.study.commons.exception.Domain;
+import shop.genieus.study.commons.exception.ValidationException;
+
+@Getter
+public class LearningGoalValidationException extends ValidationException {
+
+  private LearningGoalValidationException(String message) {
+    super(message, Domain.LEARNING_GOAL);
+  }
+
+  public static LearningGoalValidationException requiredContent() {
+    return new LearningGoalValidationException("학습 목표 내용은 필수입니다.");
+  }
+
+  public static LearningGoalValidationException exceedsContentMaxLength(int maxLength) {
+    return new LearningGoalValidationException("학습 목표 내용은 " + maxLength + "자를 초과할 수 없습니다.");
+  }
+
+  public static LearningGoalValidationException requiredDate() {
+    return new LearningGoalValidationException("목표 날짜는 필수입니다.");
+  }
+
+  public static LearningGoalValidationException invalidDate() {
+    return new LearningGoalValidationException("학습 목표는 오늘 날짜로만 설정할 수 있습니다.");
+  }
+}

--- a/src/main/java/shop/genieus/study/domains/learninggoal/infrastructure/persistence/LearningGoalRepositoryImpl.java
+++ b/src/main/java/shop/genieus/study/domains/learninggoal/infrastructure/persistence/LearningGoalRepositoryImpl.java
@@ -1,0 +1,21 @@
+package shop.genieus.study.domains.learninggoal.infrastructure.persistence;
+
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import shop.genieus.study.domains.learninggoal.application.repository.LearningGoalRepository;
+import shop.genieus.study.domains.learninggoal.domain.entity.LearningGoal;
+import shop.genieus.study.domains.learninggoal.infrastructure.persistence.repository.LearningGoalJpaRepository;
+
+@Repository
+@RequiredArgsConstructor
+public class LearningGoalRepositoryImpl implements LearningGoalRepository {
+
+  private final LearningGoalJpaRepository jpaRepository;
+
+  @Override
+  public List<LearningGoal> findByUserIdAndDate(Long userId, LocalDate date) {
+    return jpaRepository.findByUserIdAndDate(userId, date);
+  }
+}

--- a/src/main/java/shop/genieus/study/domains/learninggoal/infrastructure/persistence/LearningGoalRepositoryImpl.java
+++ b/src/main/java/shop/genieus/study/domains/learninggoal/infrastructure/persistence/LearningGoalRepositoryImpl.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import shop.genieus.study.domains.learninggoal.application.exception.LearningGoalNotFoundException;
 import shop.genieus.study.domains.learninggoal.application.repository.LearningGoalRepository;
 import shop.genieus.study.domains.learninggoal.domain.entity.LearningGoal;
 import shop.genieus.study.domains.learninggoal.infrastructure.persistence.repository.LearningGoalJpaRepository;
@@ -22,5 +23,10 @@ public class LearningGoalRepositoryImpl implements LearningGoalRepository {
   @Override
   public LearningGoal save(LearningGoal learningGoal) {
     return jpaRepository.save(learningGoal);
+  }
+
+  @Override
+  public LearningGoal findById(Long id) {
+    return jpaRepository.findById(id).orElseThrow(() -> LearningGoalNotFoundException.create(id));
   }
 }

--- a/src/main/java/shop/genieus/study/domains/learninggoal/infrastructure/persistence/LearningGoalRepositoryImpl.java
+++ b/src/main/java/shop/genieus/study/domains/learninggoal/infrastructure/persistence/LearningGoalRepositoryImpl.java
@@ -16,6 +16,11 @@ public class LearningGoalRepositoryImpl implements LearningGoalRepository {
 
   @Override
   public List<LearningGoal> findByUserIdAndDate(Long userId, LocalDate date) {
-    return jpaRepository.findByUserIdAndDate(userId, date);
+    return jpaRepository.findByUserIdAndDateOrderByCreatedAt(userId, date);
+  }
+
+  @Override
+  public LearningGoal save(LearningGoal learningGoal) {
+    return jpaRepository.save(learningGoal);
   }
 }

--- a/src/main/java/shop/genieus/study/domains/learninggoal/infrastructure/persistence/LearningGoalRepositoryImpl.java
+++ b/src/main/java/shop/genieus/study/domains/learninggoal/infrastructure/persistence/LearningGoalRepositoryImpl.java
@@ -29,4 +29,9 @@ public class LearningGoalRepositoryImpl implements LearningGoalRepository {
   public LearningGoal findById(Long id) {
     return jpaRepository.findById(id).orElseThrow(() -> LearningGoalNotFoundException.create(id));
   }
+
+  @Override
+  public void delete(LearningGoal learningGoal) {
+    jpaRepository.delete(learningGoal);
+  }
 }

--- a/src/main/java/shop/genieus/study/domains/learninggoal/infrastructure/persistence/repository/LearningGoalJpaRepository.java
+++ b/src/main/java/shop/genieus/study/domains/learninggoal/infrastructure/persistence/repository/LearningGoalJpaRepository.java
@@ -1,0 +1,11 @@
+package shop.genieus.study.domains.learninggoal.infrastructure.persistence.repository;
+
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import shop.genieus.study.domains.learninggoal.domain.entity.LearningGoal;
+
+public interface LearningGoalJpaRepository extends JpaRepository<LearningGoal, Long> {
+
+  List<LearningGoal> findByUserIdAndDateOrderByCreatedAt(Long userId, LocalDate date);
+}

--- a/src/main/java/shop/genieus/study/domains/learninggoal/presentation/LearningGoalController.java
+++ b/src/main/java/shop/genieus/study/domains/learninggoal/presentation/LearningGoalController.java
@@ -1,8 +1,14 @@
 package shop.genieus.study.domains.learninggoal.presentation;
 
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import shop.genieus.study.domains.auth.presentation.annotation.AuthPrincipal;
+import shop.genieus.study.domains.auth.presentation.dto.CustomPrincipal;
+import shop.genieus.study.domains.learninggoal.application.LearningGoalQueryService;
+import shop.genieus.study.domains.learninggoal.application.dto.info.GetLearningGoalsInfo;
+import shop.genieus.study.domains.learninggoal.application.dto.result.LearningGoalListResult;
 import shop.genieus.study.domains.learninggoal.presentation.dto.response.DeleteLearningGoalResponse;
 import shop.genieus.study.domains.learninggoal.presentation.dto.response.LearningGoalListResponse;
 import shop.genieus.study.domains.learninggoal.presentation.dto.response.LearningGoalResponse;
@@ -13,12 +19,17 @@ import shop.genieus.study.domains.learninggoal.presentation.dto.response.ToggleL
 @RequestMapping("/learning-goals")
 public class LearningGoalController {
 
-  // ================================== mock
+  private final LearningGoalQueryService queryService;
 
   @GetMapping
-  public ResponseEntity<LearningGoalListResponse> getLearningGoals( // goal list
-      @RequestParam(required = false) String date) {
-    return ResponseEntity.ok(LearningGoalListResponse.mock());
+  public ResponseEntity<LearningGoalListResponse> getLearningGoals(
+      @AuthPrincipal CustomPrincipal principal,
+      @RequestParam(required = false) LocalDate date,
+      @RequestParam Long userId) {
+    LearningGoalListResult result =
+        queryService.getLearningGoals(new GetLearningGoalsInfo(userId, principal.id(), date));
+
+    return ResponseEntity.ok(LearningGoalListResponse.from(result));
   }
 
   @PostMapping

--- a/src/main/java/shop/genieus/study/domains/learninggoal/presentation/LearningGoalController.java
+++ b/src/main/java/shop/genieus/study/domains/learninggoal/presentation/LearningGoalController.java
@@ -1,14 +1,18 @@
 package shop.genieus.study.domains.learninggoal.presentation;
 
+import jakarta.validation.Valid;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import shop.genieus.study.domains.auth.presentation.annotation.AuthPrincipal;
 import shop.genieus.study.domains.auth.presentation.dto.CustomPrincipal;
+import shop.genieus.study.domains.learninggoal.application.LearningGoalCommandService;
 import shop.genieus.study.domains.learninggoal.application.LearningGoalQueryService;
 import shop.genieus.study.domains.learninggoal.application.dto.info.GetLearningGoalsInfo;
 import shop.genieus.study.domains.learninggoal.application.dto.result.LearningGoalListResult;
+import shop.genieus.study.domains.learninggoal.domain.entity.LearningGoal;
+import shop.genieus.study.domains.learninggoal.presentation.dto.request.CreateLearningGoalRequest;
 import shop.genieus.study.domains.learninggoal.presentation.dto.response.DeleteLearningGoalResponse;
 import shop.genieus.study.domains.learninggoal.presentation.dto.response.LearningGoalListResponse;
 import shop.genieus.study.domains.learninggoal.presentation.dto.response.LearningGoalResponse;
@@ -20,6 +24,7 @@ import shop.genieus.study.domains.learninggoal.presentation.dto.response.ToggleL
 public class LearningGoalController {
 
   private final LearningGoalQueryService queryService;
+  private final LearningGoalCommandService commandService;
 
   @GetMapping
   public ResponseEntity<LearningGoalListResponse> getLearningGoals(
@@ -33,8 +38,12 @@ public class LearningGoalController {
   }
 
   @PostMapping
-  public ResponseEntity<LearningGoalResponse> createLearningGoal() { // goal detail
-    return ResponseEntity.ok(LearningGoalResponse.mock());
+  public ResponseEntity<LearningGoalResponse> createLearningGoal(
+      @AuthPrincipal CustomPrincipal principal,
+      @RequestBody @Valid CreateLearningGoalRequest request) {
+    LearningGoal goal = commandService.createLearningGoal(request.toInfo(principal));
+
+    return ResponseEntity.ok(LearningGoalResponse.from(goal));
   }
 
   @PatchMapping

--- a/src/main/java/shop/genieus/study/domains/learninggoal/presentation/LearningGoalController.java
+++ b/src/main/java/shop/genieus/study/domains/learninggoal/presentation/LearningGoalController.java
@@ -10,6 +10,7 @@ import shop.genieus.study.domains.auth.presentation.dto.CustomPrincipal;
 import shop.genieus.study.domains.learninggoal.application.LearningGoalCommandService;
 import shop.genieus.study.domains.learninggoal.application.LearningGoalQueryService;
 import shop.genieus.study.domains.learninggoal.application.dto.info.GetLearningGoalsInfo;
+import shop.genieus.study.domains.learninggoal.application.dto.info.ToggleLearningGoalInfo;
 import shop.genieus.study.domains.learninggoal.application.dto.result.LearningGoalListResult;
 import shop.genieus.study.domains.learninggoal.domain.entity.LearningGoal;
 import shop.genieus.study.domains.learninggoal.presentation.dto.request.CreateLearningGoalRequest;
@@ -34,7 +35,7 @@ public class LearningGoalController {
     LearningGoalListResult result =
         queryService.getLearningGoals(new GetLearningGoalsInfo(userId, principal.id(), date));
 
-    return ResponseEntity.ok(LearningGoalListResponse.from(result));
+    return ResponseEntity.ok().body(LearningGoalListResponse.from(result));
   }
 
   @PostMapping
@@ -43,13 +44,16 @@ public class LearningGoalController {
       @RequestBody @Valid CreateLearningGoalRequest request) {
     LearningGoal goal = commandService.createLearningGoal(request.toInfo(principal));
 
-    return ResponseEntity.ok(LearningGoalResponse.from(goal));
+    return ResponseEntity.ok().body(LearningGoalResponse.from(goal));
   }
 
-  @PatchMapping
-  public ResponseEntity<ToggleLearningGoalResponse>
-      toggleLearningGoal() { // toggle goal(목표 달성 on/off)
-    return ResponseEntity.ok(ToggleLearningGoalResponse.mock());
+  @PatchMapping("/{goalId}")
+  public ResponseEntity<ToggleLearningGoalResponse> toggleLearningGoal(
+      @AuthPrincipal CustomPrincipal principal, @PathVariable Long goalId) {
+    LearningGoal goal =
+        commandService.toggleLearningGoal(new ToggleLearningGoalInfo(principal.id(), goalId));
+
+    return ResponseEntity.ok().body(ToggleLearningGoalResponse.from(goal));
   }
 
   @DeleteMapping

--- a/src/main/java/shop/genieus/study/domains/learninggoal/presentation/LearningGoalController.java
+++ b/src/main/java/shop/genieus/study/domains/learninggoal/presentation/LearningGoalController.java
@@ -9,6 +9,7 @@ import shop.genieus.study.domains.auth.presentation.annotation.AuthPrincipal;
 import shop.genieus.study.domains.auth.presentation.dto.CustomPrincipal;
 import shop.genieus.study.domains.learninggoal.application.LearningGoalCommandService;
 import shop.genieus.study.domains.learninggoal.application.LearningGoalQueryService;
+import shop.genieus.study.domains.learninggoal.application.dto.info.DeleteLearningGoalInfo;
 import shop.genieus.study.domains.learninggoal.application.dto.info.GetLearningGoalsInfo;
 import shop.genieus.study.domains.learninggoal.application.dto.info.ToggleLearningGoalInfo;
 import shop.genieus.study.domains.learninggoal.application.dto.result.LearningGoalListResult;
@@ -56,8 +57,11 @@ public class LearningGoalController {
     return ResponseEntity.ok().body(ToggleLearningGoalResponse.from(goal));
   }
 
-  @DeleteMapping
-  public ResponseEntity<DeleteLearningGoalResponse> deleteLearningGoal() { // delete goal
-    return ResponseEntity.ok(DeleteLearningGoalResponse.mock());
+  @DeleteMapping("/{goalId}")
+  public ResponseEntity<DeleteLearningGoalResponse> deleteLearningGoal(
+      @AuthPrincipal CustomPrincipal principal, @PathVariable Long goalId) {
+    commandService.deleteLearningGoal(new DeleteLearningGoalInfo(principal.id(), goalId));
+
+    return ResponseEntity.ok().body(DeleteLearningGoalResponse.of());
   }
 }

--- a/src/main/java/shop/genieus/study/domains/learninggoal/presentation/dto/request/CreateLearningGoalRequest.java
+++ b/src/main/java/shop/genieus/study/domains/learninggoal/presentation/dto/request/CreateLearningGoalRequest.java
@@ -1,0 +1,18 @@
+package shop.genieus.study.domains.learninggoal.presentation.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import shop.genieus.study.domains.auth.presentation.dto.CustomPrincipal;
+import shop.genieus.study.domains.learninggoal.application.dto.info.CreateLearningGoalInfo;
+
+public record CreateLearningGoalRequest(
+    @NotNull(message = "날짜는 필수입니다.")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+        LocalDate date,
+    @NotBlank(message = "학습 목표 내용은 필수입니다.") String content) {
+  public CreateLearningGoalInfo toInfo(CustomPrincipal principal) {
+    return new CreateLearningGoalInfo(principal.id(), date, content);
+  }
+}

--- a/src/main/java/shop/genieus/study/domains/learninggoal/presentation/dto/response/DeleteLearningGoalResponse.java
+++ b/src/main/java/shop/genieus/study/domains/learninggoal/presentation/dto/response/DeleteLearningGoalResponse.java
@@ -1,7 +1,7 @@
 package shop.genieus.study.domains.learninggoal.presentation.dto.response;
 
 public record DeleteLearningGoalResponse(boolean success) {
-  public static DeleteLearningGoalResponse mock() {
+  public static DeleteLearningGoalResponse of() {
     return new DeleteLearningGoalResponse(true);
   }
 }

--- a/src/main/java/shop/genieus/study/domains/learninggoal/presentation/dto/response/LearningGoalListResponse.java
+++ b/src/main/java/shop/genieus/study/domains/learninggoal/presentation/dto/response/LearningGoalListResponse.java
@@ -2,15 +2,16 @@ package shop.genieus.study.domains.learninggoal.presentation.dto.response;
 
 import java.time.LocalDate;
 import java.util.List;
+import shop.genieus.study.domains.learninggoal.application.dto.result.LearningGoalListResult;
 
-public record LearningGoalListResponse(List<LearningGoalResponse> goals, boolean isOwner) {
-  public static LearningGoalListResponse mock() {
-    LocalDate today = LocalDate.now();
-    List<LearningGoalResponse> goals =
-        List.of(
-            new LearningGoalResponse(789L, today, "React 컴포넌트 생명주기와 Hooks 이해하기", true),
-            new LearningGoalResponse(790L, today, "MUI 라이브러리를 활용한 컴포넌트 스타일링 구현하기", false));
+public record LearningGoalListResponse(
+    Long userId, LocalDate date, boolean isOwner, List<LearningGoalResponse> data) {
 
-    return new LearningGoalListResponse(goals, true);
+  public static LearningGoalListResponse from(LearningGoalListResult result) {
+    return new LearningGoalListResponse(
+        result.userId(),
+        result.date(),
+        result.isOwner(),
+        result.goals().stream().map(LearningGoalResponse::from).toList());
   }
 }

--- a/src/main/java/shop/genieus/study/domains/learninggoal/presentation/dto/response/LearningGoalResponse.java
+++ b/src/main/java/shop/genieus/study/domains/learninggoal/presentation/dto/response/LearningGoalResponse.java
@@ -1,10 +1,13 @@
 package shop.genieus.study.domains.learninggoal.presentation.dto.response;
 
+import java.time.LocalDateTime;
 import shop.genieus.study.domains.learninggoal.domain.entity.LearningGoal;
 
-public record LearningGoalResponse(Long id, String content, boolean isCompleted) {
+public record LearningGoalResponse(
+    Long id, String content, boolean isCompleted, LocalDateTime createdAt) {
 
   public static LearningGoalResponse from(LearningGoal goal) {
-    return new LearningGoalResponse(goal.getId(), goal.getContent(), goal.isCompleted());
+    return new LearningGoalResponse(
+        goal.getId(), goal.getContent(), goal.isCompleted(), goal.getCreatedAt());
   }
 }

--- a/src/main/java/shop/genieus/study/domains/learninggoal/presentation/dto/response/LearningGoalResponse.java
+++ b/src/main/java/shop/genieus/study/domains/learninggoal/presentation/dto/response/LearningGoalResponse.java
@@ -1,10 +1,10 @@
 package shop.genieus.study.domains.learninggoal.presentation.dto.response;
 
-import java.time.LocalDate;
+import shop.genieus.study.domains.learninggoal.domain.entity.LearningGoal;
 
-public record LearningGoalResponse(long id, LocalDate date, String content, boolean isCompleted) {
-  public static LearningGoalResponse mock() {
-    LocalDate today = LocalDate.now();
-    return new LearningGoalResponse(789L, today, "React 컴포넌트 생명주기와 Hooks 이해하기", true);
+public record LearningGoalResponse(Long id, String content, boolean isCompleted) {
+
+  public static LearningGoalResponse from(LearningGoal goal) {
+    return new LearningGoalResponse(goal.getId(), goal.getContent(), goal.isCompleted());
   }
 }

--- a/src/main/java/shop/genieus/study/domains/learninggoal/presentation/dto/response/ToggleLearningGoalResponse.java
+++ b/src/main/java/shop/genieus/study/domains/learninggoal/presentation/dto/response/ToggleLearningGoalResponse.java
@@ -1,7 +1,11 @@
 package shop.genieus.study.domains.learninggoal.presentation.dto.response;
 
-public record ToggleLearningGoalResponse(Long id, boolean isCompleted) {
-  public static ToggleLearningGoalResponse mock() {
-    return new ToggleLearningGoalResponse(123L, false);
+import java.time.LocalDateTime;
+import shop.genieus.study.domains.learninggoal.domain.entity.LearningGoal;
+
+public record ToggleLearningGoalResponse(Long id, boolean isCompleted, LocalDateTime updatedAt) {
+
+  public static ToggleLearningGoalResponse from(LearningGoal goal) {
+    return new ToggleLearningGoalResponse(goal.getId(), goal.isCompleted(), goal.getUpdatedAt());
   }
 }


### PR DESCRIPTION
## 개요
- 스터디원들이 일일 학습 목표를 설정하고 관리할 수 있는 학습 목표 관리 시스템을 구현했습니다. 
- 사용자는 오늘 날짜의 학습 목표를 생성, 조회, 완료 상태 변경, 삭제할 수 있습니다.

## 📝 작업 내용

### 변경 사항

**도메인 엔티티 구현**
- `LearningGoal` 엔티티 생성 (오늘 날짜만 생성 가능하도록 검증 로직 포함)
- 학습 목표 내용 50자 제한 및 필수값 검증
- 완료 상태 토글 및 소유권 확인 기능

**서비스 레이어 구현**
- `LearningGoalCommandService`: 생성, 수정, 삭제 기능
- `LearningGoalQueryService`: 사용자별 일별 목표 조회 기능
- 소유권 검증을 통한 보안 강화

**API 엔드포인트 구현**
- `GET /learning-goals`: 학습 목표 목록 조회
- `POST /learning-goals`: 새 학습 목표 생성
- `PATCH /learning-goals/{goalId}`: 완료 상태 토글
- `DELETE /learning-goals/{goalId}`: 학습 목표 삭제

**데이터 접근 계층**
- 사용자별, 날짜별 인덱스 최적화
- 생성 시간 순 정렬 조회

**예외 처리**
- `LearningGoalValidationException`: 입력값 검증 예외
- `LearningGoalBusinessException`: 비즈니스 로직 예외
- `LearningGoalNotFoundException`: 엔티티 조회 예외

#### #️⃣ 연관된 이슈
closed #31

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [x] 새로운 기능 추가

## ✅ Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 학습 목표 생성, 조회, 완료 상태 토글, 삭제 기능이 추가되었습니다.
    - 학습 목표를 날짜별로 조회하고, 소유자 여부를 확인할 수 있습니다.

- **버그 수정**
    - 기존 Mock(임시) 응답이 실제 서비스 로직과 데이터로 대체되었습니다.

- **API 변경**
    - 학습 목표 관련 엔드포인트의 요청 및 응답 형식이 개선되어, 더 많은 정보(생성일시, 소유자, 날짜 등)를 제공합니다.
    - 삭제, 토글 등 응답에 성공 여부 및 변경된 시각이 포함됩니다.

- **예외 처리**
    - 학습 목표 관련 유효성 검사 및 권한, 존재하지 않는 목표에 대한 예외 처리가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->