### PR TITLE
feat: 관리자 유저 조회 기능 구현 및 유저 상태 변경 리팩토링

### DIFF
--- a/src/main/java/shop/genieus/study/domains/auth/application/dto/result/ReIssueTokenResult.java
+++ b/src/main/java/shop/genieus/study/domains/auth/application/dto/result/ReIssueTokenResult.java
@@ -2,13 +2,13 @@ package shop.genieus.study.domains.auth.application.dto.result;
 
 import shop.genieus.study.domains.auth.domain.vo.TokenPair;
 
-public record ReIssueTokenResult(
+public record TokenReissueResult(
     TokenPair tokenPair, Long userId, boolean success, TokenFailCode failCode) {
-  public static ReIssueTokenResult of(TokenPair tokenPair, Long userId) {
-    return new ReIssueTokenResult(tokenPair, userId, true, null);
+  public static TokenReissueResult of(TokenPair tokenPair, Long userId) {
+    return new TokenReissueResult(tokenPair, userId, true, null);
   }
 
-  public static ReIssueTokenResult expiredRefreshToken() {
-    return new ReIssueTokenResult(null, null, false, TokenFailCode.EXPIRE_REFRESH);
+  public static TokenReissueResult expiredRefreshToken() {
+    return new TokenReissueResult(null, null, false, TokenFailCode.EXPIRE_REFRESH);
   }
 }

--- a/src/main/java/shop/genieus/study/domains/auth/application/dto/result/ReIssueTokenResult.java
+++ b/src/main/java/shop/genieus/study/domains/auth/application/dto/result/ReIssueTokenResult.java
@@ -2,13 +2,13 @@ package shop.genieus.study.domains.auth.application.dto.result;
 
 import shop.genieus.study.domains.auth.domain.vo.TokenPair;
 
-public record TokenReissueResult(
+public record ReIssueTokenResult(
     TokenPair tokenPair, Long userId, boolean success, TokenFailCode failCode) {
-  public static TokenReissueResult of(TokenPair tokenPair, Long userId) {
-    return new TokenReissueResult(tokenPair, userId, true, null);
+  public static ReIssueTokenResult of(TokenPair tokenPair, Long userId) {
+    return new ReIssueTokenResult(tokenPair, userId, true, null);
   }
 
-  public static TokenReissueResult expiredRefreshToken() {
-    return new TokenReissueResult(null, null, false, TokenFailCode.EXPIRE_REFRESH);
+  public static ReIssueTokenResult expiredRefreshToken() {
+    return new ReIssueTokenResult(null, null, false, TokenFailCode.EXPIRE_REFRESH);
   }
 }

--- a/src/main/java/shop/genieus/study/domains/stamp/application/dto/info/get/GetStampSearchInfo.java
+++ b/src/main/java/shop/genieus/study/domains/stamp/application/dto/info/get/GetStampSearchInfo.java
@@ -3,23 +3,8 @@ package shop.genieus.study.domains.stamp.application.dto.info.get;
 import java.time.LocalDate;
 import org.springframework.data.domain.Pageable;
 import shop.genieus.study.domains.stamp.domain.vo.StampType;
-import shop.genieus.study.domains.stamp.presentation.dto.request.StampFilterParams;
 
 public record GetStampSearchInfo(StampFilterInfo filterParams, Pageable pageable) {
-  public static GetStampSearchInfo from(StampFilterParams params, Pageable pageable) {
-
-    StampFilterInfo filter =
-        new StampFilterInfo(
-            params.getType(),
-            params.getTitle(),
-            params.getCategory(),
-            params.getStartDate(),
-            params.getEndDate(),
-            params.getSortBy(),
-            params.getSortDirection());
-    return new GetStampSearchInfo(filter, pageable);
-  }
-
   public record StampFilterInfo(
       StampType type,
       String title,

--- a/src/main/java/shop/genieus/study/domains/stamp/presentation/StampController.java
+++ b/src/main/java/shop/genieus/study/domains/stamp/presentation/StampController.java
@@ -22,6 +22,7 @@ import shop.genieus.study.domains.stamp.application.dto.result.CreateResumeStamp
 import shop.genieus.study.domains.stamp.application.dto.result.CreateTilStampResult;
 import shop.genieus.study.domains.stamp.application.dto.result.GetStampSearchResult;
 import shop.genieus.study.domains.stamp.domain.entity.*;
+import shop.genieus.study.domains.stamp.presentation.dto.StampMapper;
 import shop.genieus.study.domains.stamp.presentation.dto.request.CreateCtStampRequest;
 import shop.genieus.study.domains.stamp.presentation.dto.request.CreateResumeStampRequest;
 import shop.genieus.study.domains.stamp.presentation.dto.request.CreateTilStampRequest;
@@ -42,6 +43,8 @@ public class StampController {
   private final StampHistoryService stampHistoryService;
   private final StampViewService stampViewService;
   private final StampCategoryService stampCategoryService;
+
+  private final StampMapper mapper;
 
   @PostMapping("/ct")
   public ResponseEntity<CreateCtStampResponse> createCtStamp(
@@ -123,7 +126,7 @@ public class StampController {
       @ModelAttribute StampFilterParams filterParams,
       @PageableDefault(page = 0, size = 10) Pageable pageable) {
     GetStampSearchResult result =
-        stampViewService.searchStampViews(GetStampSearchInfo.from(filterParams, pageable));
+        stampViewService.searchStampViews(mapper.toInfo(filterParams, pageable));
     return ResponseEntity.ok().body(StampListResponse.from(result));
   }
 

--- a/src/main/java/shop/genieus/study/domains/stamp/presentation/dto/StampMapper.java
+++ b/src/main/java/shop/genieus/study/domains/stamp/presentation/dto/StampMapper.java
@@ -1,0 +1,23 @@
+package shop.genieus.study.domains.stamp.presentation.dto;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+import shop.genieus.study.domains.stamp.application.dto.info.get.GetStampSearchInfo;
+import shop.genieus.study.domains.stamp.presentation.dto.request.StampFilterParams;
+
+@Component
+public class StampMapper {
+  public GetStampSearchInfo toInfo(StampFilterParams params, Pageable pageable) {
+
+    GetStampSearchInfo.StampFilterInfo filter =
+        new GetStampSearchInfo.StampFilterInfo(
+            params.getType(),
+            params.getTitle(),
+            params.getCategory(),
+            params.getStartDate(),
+            params.getEndDate(),
+            params.getSortBy(),
+            params.getSortDirection());
+    return new GetStampSearchInfo(filter, pageable);
+  }
+}

--- a/src/main/java/shop/genieus/study/domains/user/application/UserCommandService.java
+++ b/src/main/java/shop/genieus/study/domains/user/application/UserCommandService.java
@@ -14,9 +14,9 @@ import shop.genieus.study.domains.user.application.dto.info.UpdateUserSettingInf
 import shop.genieus.study.domains.user.application.repository.UserCacheRepository;
 import shop.genieus.study.domains.user.application.repository.UserRepository;
 import shop.genieus.study.domains.user.domain.entity.User;
+import shop.genieus.study.domains.user.domain.exception.UserSameSettingException;
 import shop.genieus.study.domains.user.domain.exception.UserValidationException;
 import shop.genieus.study.domains.user.domain.vo.ParticipationStatus;
-import shop.genieus.study.domains.user.domain.vo.UserSettings;
 
 @Slf4j
 @Service
@@ -55,11 +55,16 @@ public class UserCommandService {
       throw UserValidationException.userNotPending();
     }
 
-    targetUser.approveWithParticipation(info.isParticipating());
+    try {
+      targetUser.approveWithParticipation(info.isApproved(), info.isParticipating());
+    } catch (UserSameSettingException e) {
+      log.info(e.getMessage());
+    }
     User updated = repository.save(targetUser);
 
     LocalDate today = dateTimeProvider.getCurrentDate();
-    historyCommandService.updateSettingHistory(updated, today);
+    historyCommandService.updateSettingHistory(
+        updated, today, targetUser.isRejected() ? "회원 승인거부" : "회원 승인");
 
     if (updated.isParticipating()) {
       userCacheRepository.invalidateParticipatingUsers();
@@ -84,7 +89,7 @@ public class UserCommandService {
 
     User updated = repository.save(user);
     LocalDate today = dateTimeProvider.getCurrentDate();
-    historyCommandService.updateSettingHistory(updated, today);
+    historyCommandService.updateSettingHistory(updated, today, "희망 코어시각 수정");
 
     log.info(
         "사용자 설정 변경: userId={}, checkInTime={}, coreTime={}", userId, newCheckInTime, newCoreTime);
@@ -94,30 +99,24 @@ public class UserCommandService {
     Long adminUserId = info.adminUserId();
     Long targetUserId = info.targetUserId();
     ParticipationStatus newStatus = info.participationStatus();
+    String reason = info.reason();
 
     User targetUser = findById(targetUserId);
-    UserSettings currentSettings = targetUser.getCurrentSettings();
-    ParticipationStatus currentStatus = currentSettings.getParticipationStatus();
-
-    if (currentStatus == newStatus) {
-      throw UserValidationException.sameParticipationStatus();
-    }
-
-    targetUser.updateSettings(
-        currentSettings.getDesiredCheckInTime(), currentSettings.getDesiredCoreTime(), newStatus);
-
+    targetUser.updateParticipationStatus(newStatus);
     User updated = repository.save(targetUser);
+
     LocalDate today = dateTimeProvider.getCurrentDate();
-    historyCommandService.updateSettingHistory(updated, today);
+    historyCommandService.updateSettingHistory(updated, today, reason);
 
     userCacheRepository.invalidateParticipatingUsers();
 
     log.info(
-        "참여 상태 변경: adminUserId={}, targetUserId={}, {} -> {}",
+        "참여 상태 변경: adminUserId={}, targetUserId={}, {} -> {}, 이유={}",
         adminUserId,
         targetUserId,
-        currentStatus,
-        newStatus);
+        targetUser.getParticipationStatus(),
+        newStatus,
+        reason);
   }
 
   private User findById(Long userId) {

--- a/src/main/java/shop/genieus/study/domains/user/application/UserQueryService.java
+++ b/src/main/java/shop/genieus/study/domains/user/application/UserQueryService.java
@@ -10,6 +10,8 @@ import org.springframework.transaction.annotation.Transactional;
 import shop.genieus.study.commons.provider.UserProvider;
 import shop.genieus.study.commons.provider.model.UserInfo;
 import shop.genieus.study.commons.provider.model.UserSettingHistoryInfo;
+import shop.genieus.study.domains.user.application.dto.info.GetAdminUserSearchInfo;
+import shop.genieus.study.domains.user.application.dto.result.GetAdminUserSearchResult;
 import shop.genieus.study.domains.user.application.dto.result.UserInfoResult;
 import shop.genieus.study.domains.user.application.exception.UserNotFoundException;
 import shop.genieus.study.domains.user.application.mapper.UserMapper;
@@ -94,6 +96,10 @@ public class UserQueryService implements UserProvider {
 
     userCacheRepository.saveParticipatingUsers(users);
     return users;
+  }
+
+  public GetAdminUserSearchResult getAdminUserList(GetAdminUserSearchInfo searchInfo) {
+    return repository.findUsers(searchInfo.filterParams(), searchInfo.pageable());
   }
 
   private User findById(Long userId) {

--- a/src/main/java/shop/genieus/study/domains/user/application/UserSettingHistoryCommandService.java
+++ b/src/main/java/shop/genieus/study/domains/user/application/UserSettingHistoryCommandService.java
@@ -26,12 +26,13 @@ public class UserSettingHistoryCommandService {
         today,
         settings.getDesiredCheckInTime(),
         settings.getDesiredCoreTime(),
-        settings.getParticipationStatus());
+        settings.getParticipationStatus(),
+        "신규 회원 가입");
 
     log.info("초기 설정 이력 생성: userId={}", user.getId());
   }
 
-  public void updateSettingHistory(User user, LocalDate effectiveDate) {
+  public void updateSettingHistory(User user, LocalDate effectiveDate, String reason) {
     Long userId = user.getId();
     deactivateCurrentHistory(userId, effectiveDate);
 
@@ -41,7 +42,8 @@ public class UserSettingHistoryCommandService {
         effectiveDate,
         settings.getDesiredCheckInTime(),
         settings.getDesiredCoreTime(),
-        settings.getParticipationStatus());
+        settings.getParticipationStatus(),
+        reason);
   }
 
   private void deactivateCurrentHistory(Long userId, LocalDate effectiveDate) {
@@ -57,11 +59,12 @@ public class UserSettingHistoryCommandService {
       LocalDate effectiveDate,
       LocalTime checkInTime,
       int coreTime,
-      ParticipationStatus participationStatus) {
+      ParticipationStatus participationStatus,
+      String reason) {
 
     UserSettingHistory newHistory =
         UserSettingHistory.create(
-            userId, effectiveDate, checkInTime, coreTime, participationStatus);
+            userId, effectiveDate, checkInTime, coreTime, participationStatus, reason);
     settingHistoryRepository.save(newHistory);
 
     log.info("새 설정 이력 생성: userId={}, effectiveFromDate={}", userId, effectiveDate);

--- a/src/main/java/shop/genieus/study/domains/user/application/dto/info/AdminUserInfo.java
+++ b/src/main/java/shop/genieus/study/domains/user/application/dto/info/AdminUserInfo.java
@@ -1,0 +1,49 @@
+package shop.genieus.study.domains.user.application.dto.info;
+
+import com.querydsl.core.annotations.QueryProjection;
+import java.time.LocalDateTime;
+import shop.genieus.study.domains.user.domain.entity.User;
+import shop.genieus.study.domains.user.domain.vo.ParticipationStatus;
+
+public record AdminUserInfo(
+    Long id,
+    String nickname,
+    String email,
+    String status,
+    ParticipationStatus participationStatus,
+    String role,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt) {
+
+  @QueryProjection
+  public AdminUserInfo(
+      Long id,
+      String nickname,
+      String email,
+      String status,
+      ParticipationStatus participationStatus,
+      String role,
+      LocalDateTime createdAt,
+      LocalDateTime updatedAt) {
+    this.id = id;
+    this.nickname = nickname;
+    this.email = email;
+    this.status = status;
+    this.participationStatus = participationStatus;
+    this.role = role;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+  }
+
+  public static AdminUserInfo from(User user) {
+    return new AdminUserInfo(
+        user.getId(),
+        user.getNickname().getValue(),
+        user.getEmail().getValue(),
+        user.getStatus().name(),
+        user.getParticipationStatus(),
+        user.getRole().name(),
+        user.getCreatedAt(),
+        user.getUpdatedAt());
+  }
+}

--- a/src/main/java/shop/genieus/study/domains/user/application/dto/info/ApproveUserInfo.java
+++ b/src/main/java/shop/genieus/study/domains/user/application/dto/info/ApproveUserInfo.java
@@ -1,4 +1,4 @@
 package shop.genieus.study.domains.user.application.dto.info;
 
-
-public record ApproveUserInfo(Long adminUserId, Long targetUserId, Boolean isParticipating) {}
+public record ApproveUserInfo(
+    Long adminUserId, Long targetUserId, Boolean isApproved, Boolean isParticipating) {}

--- a/src/main/java/shop/genieus/study/domains/user/application/dto/info/GetAdminUserSearchInfo.java
+++ b/src/main/java/shop/genieus/study/domains/user/application/dto/info/GetAdminUserSearchInfo.java
@@ -1,0 +1,26 @@
+package shop.genieus.study.domains.user.application.dto.info;
+
+import org.springframework.data.domain.Pageable;
+import shop.genieus.study.domains.user.presentation.dto.request.AdminUserFilterParams;
+
+public record GetAdminUserSearchInfo(AdminUserFilterInfo filterParams, Pageable pageable) {
+  public static GetAdminUserSearchInfo from(AdminUserFilterParams params, Pageable pageable) {
+    AdminUserFilterInfo filter =
+        new AdminUserFilterInfo(
+            params.getStatus(),
+            params.getParticipationStatus(),
+            params.getNickname(),
+            params.getEmail(),
+            params.getSortBy(),
+            params.getSortDirection());
+    return new GetAdminUserSearchInfo(filter, pageable);
+  }
+
+  public record AdminUserFilterInfo(
+      String status,
+      String participationStatus,
+      String nickname,
+      String email,
+      String sortBy,
+      String sortDirection) {}
+}

--- a/src/main/java/shop/genieus/study/domains/user/application/dto/info/UpdateParticipationStatusInfo.java
+++ b/src/main/java/shop/genieus/study/domains/user/application/dto/info/UpdateParticipationStatusInfo.java
@@ -3,4 +3,4 @@ package shop.genieus.study.domains.user.application.dto.info;
 import shop.genieus.study.domains.user.domain.vo.ParticipationStatus;
 
 public record UpdateParticipationStatusInfo(
-    Long adminUserId, Long targetUserId, ParticipationStatus participationStatus) {}
+    Long adminUserId, Long targetUserId, ParticipationStatus participationStatus, String reason) {}

--- a/src/main/java/shop/genieus/study/domains/user/application/dto/result/GetAdminUserSearchResult.java
+++ b/src/main/java/shop/genieus/study/domains/user/application/dto/result/GetAdminUserSearchResult.java
@@ -1,0 +1,6 @@
+package shop.genieus.study.domains.user.application.dto.result;
+
+import java.util.List;
+import shop.genieus.study.domains.user.application.dto.info.AdminUserInfo;
+
+public record GetAdminUserSearchResult(List<AdminUserInfo> content, PageInfo page) {}

--- a/src/main/java/shop/genieus/study/domains/user/application/dto/result/PageInfo.java
+++ b/src/main/java/shop/genieus/study/domains/user/application/dto/result/PageInfo.java
@@ -1,0 +1,3 @@
+package shop.genieus.study.domains.user.application.dto.result;
+
+public record PageInfo(int page, int size, long totalElements, int totalPages, boolean last) {}

--- a/src/main/java/shop/genieus/study/domains/user/application/repository/UserRepository.java
+++ b/src/main/java/shop/genieus/study/domains/user/application/repository/UserRepository.java
@@ -1,6 +1,9 @@
 package shop.genieus.study.domains.user.application.repository;
 
 import java.util.List;
+import org.springframework.data.domain.Pageable;
+import shop.genieus.study.domains.user.application.dto.info.GetAdminUserSearchInfo;
+import shop.genieus.study.domains.user.application.dto.result.GetAdminUserSearchResult;
 import shop.genieus.study.domains.user.domain.entity.User;
 
 public interface UserRepository {
@@ -17,4 +20,7 @@ public interface UserRepository {
   List<User> findAllActiveUsers();
 
   List<User> findAllParticipatingUsers();
+
+  GetAdminUserSearchResult findUsers(
+      GetAdminUserSearchInfo.AdminUserFilterInfo filterInfo, Pageable pageable);
 }

--- a/src/main/java/shop/genieus/study/domains/user/domain/entity/User.java
+++ b/src/main/java/shop/genieus/study/domains/user/domain/entity/User.java
@@ -7,6 +7,7 @@ import lombok.*;
 import org.hibernate.annotations.Comment;
 import shop.genieus.study.commons.jpa.BaseEntity;
 import shop.genieus.study.domains.user.application.PasswordEncryptionService;
+import shop.genieus.study.domains.user.domain.exception.UserSameSettingException;
 import shop.genieus.study.domains.user.domain.exception.UserValidationException;
 import shop.genieus.study.domains.user.domain.vo.*;
 
@@ -79,23 +80,35 @@ public class User extends BaseEntity {
   public void updateSettings(
       LocalTime newCheckInTime, int newCoreTime, ParticipationStatus newParticipationStatus) {
     if (currentSettings.isSameAs(newCheckInTime, newCoreTime, newParticipationStatus)) {
-      throw UserValidationException.sameSetting();
+      throw new UserSameSettingException();
     }
 
     UserSettings newSettings = UserSettings.of(newCheckInTime, newCoreTime, newParticipationStatus);
     this.currentSettings = newSettings;
   }
 
-  public void approveWithParticipation(boolean isParticipating) {
-    approve();
+  public void approveWithParticipation(boolean isApproved, boolean isParticipating) {
+    approve(isApproved);
     updateParticipation(isParticipating);
   }
 
-  public void approve() {
+  public void approve(boolean isApproved) {
     if (!this.status.isPending()) {
       throw UserValidationException.userNotPending();
     }
-    this.status = AccountStatus.APPROVED;
+    this.status = isApproved ? AccountStatus.APPROVED : AccountStatus.REJECTED;
+  }
+
+  public void updateParticipationStatus(ParticipationStatus newStatus) {
+    UserSettings currentSettings = getCurrentSettings();
+    ParticipationStatus currentStatus = currentSettings.getParticipationStatus();
+
+    if (currentStatus == newStatus) {
+      throw UserValidationException.sameParticipationStatus();
+    }
+
+    updateSettings(
+        currentSettings.getDesiredCheckInTime(), currentSettings.getDesiredCoreTime(), newStatus);
   }
 
   public void updateParticipation(boolean isParticipating) {
@@ -139,5 +152,9 @@ public class User extends BaseEntity {
 
   public boolean isParticipating() {
     return this.currentSettings.isParticipating();
+  }
+
+  public ParticipationStatus getParticipationStatus() {
+    return currentSettings.getParticipationStatus();
   }
 }

--- a/src/main/java/shop/genieus/study/domains/user/domain/entity/UserSettingHistory.java
+++ b/src/main/java/shop/genieus/study/domains/user/domain/entity/UserSettingHistory.java
@@ -1,5 +1,7 @@
 package shop.genieus.study.domains.user.domain.entity;
 
+import static org.springframework.util.StringUtils.hasText;
+
 import jakarta.persistence.*;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -21,7 +23,6 @@ import shop.genieus.study.domains.user.domain.vo.ParticipationStatus;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserSettingHistory extends BaseEntity {
-
   @Id
   @Comment("유저 설정 이력 아이디")
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -55,12 +56,17 @@ public class UserSettingHistory extends BaseEntity {
   @Enumerated(EnumType.STRING)
   private ParticipationStatus participationStatus;
 
+  @Comment("변경 이유")
+  @Column(name = "reason", length = 100)
+  private String reason;
+
   public static UserSettingHistory create(
       Long userId,
       LocalDate effectiveFromDate,
       LocalTime desiredCheckInTime,
       int desiredCoreTime,
-      ParticipationStatus participationStatus) {
+      ParticipationStatus participationStatus,
+      String reason) {
 
     return UserSettingHistory.builder()
         .userId(userId)
@@ -69,6 +75,7 @@ public class UserSettingHistory extends BaseEntity {
         .desiredCoreTime(desiredCoreTime)
         .participationStatus(participationStatus)
         .isActive(true)
+        .reason(hasText(reason) ? reason : null)
         .build();
   }
 

--- a/src/main/java/shop/genieus/study/domains/user/domain/exception/UserSameSettingException.java
+++ b/src/main/java/shop/genieus/study/domains/user/domain/exception/UserSameSettingException.java
@@ -1,0 +1,16 @@
+package shop.genieus.study.domains.user.domain.exception;
+
+import lombok.Getter;
+import shop.genieus.study.commons.exception.Domain;
+import shop.genieus.study.commons.exception.ValidationException;
+
+@Getter
+public class UserSameSettingException extends ValidationException {
+  private UserSameSettingException(String message) {
+    super(message, Domain.USER);
+  }
+
+  public UserSameSettingException() {
+    this("기존 설정과 동일합니다.");
+  }
+}

--- a/src/main/java/shop/genieus/study/domains/user/domain/exception/UserValidationException.java
+++ b/src/main/java/shop/genieus/study/domains/user/domain/exception/UserValidationException.java
@@ -88,10 +88,6 @@ public class UserValidationException extends ValidationException {
     return new UserValidationException(String.format("코어 시간은 %d분-%d분 사이여야 합니다.", min, max));
   }
 
-  public static UserValidationException sameSetting() {
-    return new UserValidationException("기존 설정과 동일합니다.");
-  }
-
   public static UserValidationException requiredParticipationStatus() {
     return new UserValidationException("참여 상태는 필수입니다.");
   }

--- a/src/main/java/shop/genieus/study/domains/user/infrastructure/persistence/UserRepositoryImpl.java
+++ b/src/main/java/shop/genieus/study/domains/user/infrastructure/persistence/UserRepositoryImpl.java
@@ -2,7 +2,13 @@ package shop.genieus.study.domains.user.infrastructure.persistence;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
+import shop.genieus.study.domains.user.application.dto.info.AdminUserInfo;
+import shop.genieus.study.domains.user.application.dto.info.GetAdminUserSearchInfo;
+import shop.genieus.study.domains.user.application.dto.result.GetAdminUserSearchResult;
+import shop.genieus.study.domains.user.application.dto.result.PageInfo;
 import shop.genieus.study.domains.user.application.exception.UserNotFoundException;
 import shop.genieus.study.domains.user.application.repository.UserRepository;
 import shop.genieus.study.domains.user.domain.entity.User;
@@ -10,11 +16,13 @@ import shop.genieus.study.domains.user.domain.exception.UserValidationException;
 import shop.genieus.study.domains.user.domain.vo.Email;
 import shop.genieus.study.domains.user.domain.vo.Nickname;
 import shop.genieus.study.domains.user.infrastructure.persistence.repository.UserJpaRepository;
+import shop.genieus.study.domains.user.infrastructure.persistence.repository.UserSearchRepository;
 
 @Repository
 @RequiredArgsConstructor
 public class UserRepositoryImpl implements UserRepository {
   private final UserJpaRepository jpaRepository;
+  private final UserSearchRepository searchRepository;
 
   @Override
   public User save(User user) {
@@ -51,5 +59,20 @@ public class UserRepositoryImpl implements UserRepository {
   @Override
   public List<User> findAllParticipatingUsers() {
     return jpaRepository.findAllParticipatingUsers();
+  }
+
+  @Override
+  public GetAdminUserSearchResult findUsers(
+      GetAdminUserSearchInfo.AdminUserFilterInfo filterInfo, Pageable pageable) {
+    Page<AdminUserInfo> userPage = searchRepository.findUsers(filterInfo, pageable);
+    PageInfo pageInfo =
+        new PageInfo(
+            userPage.getNumber(),
+            userPage.getSize(),
+            userPage.getTotalElements(),
+            userPage.getTotalPages(),
+            userPage.isLast());
+
+    return new GetAdminUserSearchResult(userPage.getContent(), pageInfo);
   }
 }

--- a/src/main/java/shop/genieus/study/domains/user/infrastructure/persistence/repository/UserSearchRepository.java
+++ b/src/main/java/shop/genieus/study/domains/user/infrastructure/persistence/repository/UserSearchRepository.java
@@ -1,0 +1,131 @@
+package shop.genieus.study.domains.user.infrastructure.persistence.repository;
+
+import static shop.genieus.study.domains.user.domain.entity.QUser.user;
+
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+import shop.genieus.study.domains.user.application.dto.info.AdminUserInfo;
+import shop.genieus.study.domains.user.application.dto.info.GetAdminUserSearchInfo;
+import shop.genieus.study.domains.user.application.dto.info.QAdminUserInfo;
+import shop.genieus.study.domains.user.domain.vo.AccountStatus;
+import shop.genieus.study.domains.user.domain.vo.ParticipationStatus;
+
+@Repository
+@RequiredArgsConstructor
+public class UserSearchRepository {
+  private final JPAQueryFactory queryFactory;
+
+  private final Map<String, Expression<?>> sortFieldMap =
+      Map.of(
+          "createdat", user.createdAt,
+          "updatedat", user.updatedAt,
+          "nickname", user.nickname.value,
+          "email", user.email.value,
+          "status", user.status);
+
+  public Page<AdminUserInfo> findUsers(
+      GetAdminUserSearchInfo.AdminUserFilterInfo filterInfo, Pageable pageable) {
+    List<BooleanExpression> conditions = buildConditions(filterInfo);
+    BooleanExpression whereCondition =
+        conditions.stream().reduce(BooleanExpression::and).orElse(null);
+
+    List<AdminUserInfo> content =
+        queryFactory
+            .select(
+                new QAdminUserInfo(
+                    user.id,
+                    user.nickname.value,
+                    user.email.value,
+                    user.status.stringValue(),
+                    user.currentSettings.participationStatus,
+                    user.role.stringValue(),
+                    user.createdAt,
+                    user.updatedAt))
+            .from(user)
+            .where(whereCondition)
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .orderBy(getOrderSpecifier(filterInfo))
+            .fetch();
+
+    JPAQuery<Long> countQuery = queryFactory.select(user.count()).from(user).where(whereCondition);
+
+    return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+  }
+
+  private List<BooleanExpression> buildConditions(
+      GetAdminUserSearchInfo.AdminUserFilterInfo filterInfo) {
+    List<BooleanExpression> conditions = new ArrayList<>();
+
+    // 상태 필터
+    if (filterInfo.status() != null && !filterInfo.status().isBlank()) {
+      conditions.add(statusEq(filterInfo.status()));
+    }
+
+    // 참여 상태 필터
+    if (filterInfo.participationStatus() != null && !filterInfo.participationStatus().isBlank()) {
+      conditions.add(participationStatusEq(filterInfo.participationStatus()));
+    }
+
+    // 닉네임 검색
+    if (filterInfo.nickname() != null && !filterInfo.nickname().isBlank()) {
+      conditions.add(nicknameContains(filterInfo.nickname()));
+    }
+
+    // 이메일 검색
+    if (filterInfo.email() != null && !filterInfo.email().isBlank()) {
+      conditions.add(emailContains(filterInfo.email()));
+    }
+
+    return conditions;
+  }
+
+  private BooleanExpression statusEq(String status) {
+    try {
+      AccountStatus userStatus = AccountStatus.valueOf(status.toUpperCase());
+      return user.status.eq(userStatus);
+    } catch (IllegalArgumentException e) {
+      return null;
+    }
+  }
+
+  private BooleanExpression participationStatusEq(String participationStatus) {
+    ParticipationStatus userStatus = ParticipationStatus.valueOf(participationStatus.toUpperCase());
+    return user.currentSettings.participationStatus.eq(userStatus);
+  }
+
+  private BooleanExpression nicknameContains(String nickname) {
+    return user.nickname.value.containsIgnoreCase(nickname);
+  }
+
+  private BooleanExpression emailContains(String email) {
+    return user.email.value.containsIgnoreCase(email);
+  }
+
+  private OrderSpecifier<?>[] getOrderSpecifier(
+      GetAdminUserSearchInfo.AdminUserFilterInfo filterInfo) {
+    String sortBy = filterInfo.sortBy() != null ? filterInfo.sortBy() : "createdAt";
+    String sortDirection = filterInfo.sortDirection() != null ? filterInfo.sortDirection() : "desc";
+
+    Expression<?> sortExpression = sortFieldMap.get(sortBy.toLowerCase());
+    if (sortExpression == null) {
+      sortExpression = user.createdAt;
+    }
+
+    Order order = "asc".equalsIgnoreCase(sortDirection) ? Order.ASC : Order.DESC;
+
+    return new OrderSpecifier[] {new OrderSpecifier(order, sortExpression)};
+  }
+}

--- a/src/main/java/shop/genieus/study/domains/user/presentation/AdminUserController.java
+++ b/src/main/java/shop/genieus/study/domains/user/presentation/AdminUserController.java
@@ -2,14 +2,21 @@ package shop.genieus.study.domains.user.presentation;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import shop.genieus.study.domains.auth.presentation.annotation.AuthPrincipal;
 import shop.genieus.study.domains.auth.presentation.dto.CustomPrincipal;
 import shop.genieus.study.domains.user.application.UserCommandService;
+import shop.genieus.study.domains.user.application.UserQueryService;
+import shop.genieus.study.domains.user.application.dto.result.GetAdminUserSearchResult;
+import shop.genieus.study.domains.user.presentation.dto.UserInfoMapper;
+import shop.genieus.study.domains.user.presentation.dto.request.AdminUserFilterParams;
 import shop.genieus.study.domains.user.presentation.dto.request.ApproveUserRequest;
 import shop.genieus.study.domains.user.presentation.dto.request.UpdateParticipationStatusRequest;
+import shop.genieus.study.domains.user.presentation.dto.response.AdminUserListResponse;
 
 @RestController
 @RequiredArgsConstructor
@@ -17,6 +24,8 @@ import shop.genieus.study.domains.user.presentation.dto.request.UpdateParticipat
 @PreAuthorize("hasRole('ADMIN')")
 public class AdminUserController {
   private final UserCommandService userCommandService;
+  private final UserQueryService userQueryService;
+  private final UserInfoMapper userInfoMapper;
 
   @PostMapping("/{userId}/approve")
   public ResponseEntity<Void> approveUser(
@@ -38,5 +47,16 @@ public class AdminUserController {
     userCommandService.updateParticipationStatus(request.toInfo(principal.id(), userId));
 
     return ResponseEntity.noContent().build();
+  }
+
+  @GetMapping
+  public ResponseEntity<AdminUserListResponse> getUserList(
+      @ModelAttribute AdminUserFilterParams filterParams,
+      @PageableDefault(page = 0, size = 10) Pageable pageable) {
+
+    GetAdminUserSearchResult result =
+        userQueryService.getAdminUserList(userInfoMapper.toInfo(filterParams, pageable));
+
+    return ResponseEntity.ok(AdminUserListResponse.from(result));
   }
 }

--- a/src/main/java/shop/genieus/study/domains/user/presentation/dto/UserInfoMapper.java
+++ b/src/main/java/shop/genieus/study/domains/user/presentation/dto/UserInfoMapper.java
@@ -1,0 +1,21 @@
+package shop.genieus.study.domains.user.presentation.dto;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+import shop.genieus.study.domains.user.application.dto.info.GetAdminUserSearchInfo;
+import shop.genieus.study.domains.user.presentation.dto.request.AdminUserFilterParams;
+
+@Component
+public class UserInfoMapper {
+  public GetAdminUserSearchInfo toInfo(AdminUserFilterParams params, Pageable pageable) {
+    GetAdminUserSearchInfo.AdminUserFilterInfo filter =
+        new GetAdminUserSearchInfo.AdminUserFilterInfo(
+            params.getStatus(),
+            params.getParticipationStatus(),
+            params.getNickname(),
+            params.getEmail(),
+            params.getSortBy(),
+            params.getSortDirection());
+    return new GetAdminUserSearchInfo(filter, pageable);
+  }
+}

--- a/src/main/java/shop/genieus/study/domains/user/presentation/dto/request/AdminUserFilterParams.java
+++ b/src/main/java/shop/genieus/study/domains/user/presentation/dto/request/AdminUserFilterParams.java
@@ -1,0 +1,15 @@
+package shop.genieus.study.domains.user.presentation.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AdminUserFilterParams {
+  private String status;
+  private String participationStatus;
+  private String nickname;
+  private String email;
+  private String sortBy = "createdAt";
+  private String sortDirection = "DESC";
+}

--- a/src/main/java/shop/genieus/study/domains/user/presentation/dto/request/ApproveUserRequest.java
+++ b/src/main/java/shop/genieus/study/domains/user/presentation/dto/request/ApproveUserRequest.java
@@ -3,9 +3,11 @@ package shop.genieus.study.domains.user.presentation.dto.request;
 import jakarta.validation.constraints.NotNull;
 import shop.genieus.study.domains.user.application.dto.info.ApproveUserInfo;
 
-public record ApproveUserRequest(@NotNull(message = "참여 여부는 필수입니다.") Boolean isParticipating) {
+public record ApproveUserRequest(
+    @NotNull(message = "승인 여부는 필수입니다.") Boolean isApproved,
+    @NotNull(message = "참여 여부는 필수입니다.") Boolean isParticipating) {
 
   public ApproveUserInfo toInfo(Long adminUserId, Long targetUserId) {
-    return new ApproveUserInfo(adminUserId, targetUserId, isParticipating);
+    return new ApproveUserInfo(adminUserId, targetUserId, isApproved, isParticipating);
   }
 }

--- a/src/main/java/shop/genieus/study/domains/user/presentation/dto/request/UpdateParticipationStatusRequest.java
+++ b/src/main/java/shop/genieus/study/domains/user/presentation/dto/request/UpdateParticipationStatusRequest.java
@@ -5,9 +5,10 @@ import shop.genieus.study.domains.user.application.dto.info.UpdateParticipationS
 import shop.genieus.study.domains.user.domain.vo.ParticipationStatus;
 
 public record UpdateParticipationStatusRequest(
-    @NotNull(message = "참여 상태는 필수입니다.") ParticipationStatus participationStatus) {
+    @NotNull(message = "참여 상태는 필수입니다.") ParticipationStatus participationStatus, String reason) {
 
   public UpdateParticipationStatusInfo toInfo(Long adminUserId, Long targetUserId) {
-    return new UpdateParticipationStatusInfo(adminUserId, targetUserId, participationStatus);
+    return new UpdateParticipationStatusInfo(
+        adminUserId, targetUserId, participationStatus, reason);
   }
 }

--- a/src/main/java/shop/genieus/study/domains/user/presentation/dto/response/AdminUserListResponse.java
+++ b/src/main/java/shop/genieus/study/domains/user/presentation/dto/response/AdminUserListResponse.java
@@ -1,0 +1,39 @@
+package shop.genieus.study.domains.user.presentation.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import shop.genieus.study.domains.user.application.dto.info.AdminUserInfo;
+import shop.genieus.study.domains.user.application.dto.result.GetAdminUserSearchResult;
+import shop.genieus.study.domains.user.application.dto.result.PageInfo;
+import shop.genieus.study.domains.user.domain.vo.ParticipationStatus;
+
+public record AdminUserListResponse(List<UserData> content, PageInfo page) {
+  public static AdminUserListResponse from(GetAdminUserSearchResult result) {
+    return new AdminUserListResponse(
+        result.content().stream().map(data -> UserData.from(data)).toList(), result.page());
+  }
+
+  public record UserData(
+      Long id,
+      String nickname,
+      String email,
+      String status,
+      String participationStatus,
+      boolean isParticipating,
+      String role,
+      LocalDateTime createdAt,
+      LocalDateTime updatedAt) {
+    public static UserData from(AdminUserInfo info) {
+      return new UserData(
+          info.id(),
+          info.nickname(),
+          info.email(),
+          info.status(),
+          info.participationStatus().name(),
+          info.participationStatus() == ParticipationStatus.ACTIVE,
+          info.role(),
+          info.createdAt(),
+          info.updatedAt());
+    }
+  }
+}


### PR DESCRIPTION
## 개요
관리자 유저 조회 기능 구현 및 유저 상태 변경 리팩토링

## 📝 작업 내용

### 변경 사항
- 사용자 승인/참여 상태 관리 로직 개선
- 관리자용 사용자 검색 및 필터링 API 추가  
- 설정 변경 이력에 변경 이유 추가
- QueryDSL 기반 동적 검색 쿼리

### 주요 기능
1. 사용자 승인/거부 처리 개선
2. 참여 상태 변경 시 이유 기록
3. 관리자 대시보드 및 통계 기능
4. 실시간 사용자 검색 및 필터링

## PR 유형
- [x] 새로운 기능 추가
- [x] 코드 리팩토링

## ✅ Check List
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [ ] CI/CD 파이프라인을 통과했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 관리자가 사용자 목록을 필터 및 페이징하여 조회할 수 있는 엔드포인트가 추가되었습니다.
  - 관리 사용자 검색 결과 및 페이지네이션 정보를 제공하는 응답 구조가 도입되었습니다.
  - 사용자 정보 및 설정 변경 이력에 변경 사유(reason)를 기록할 수 있게 되었습니다.

- **기능 개선**
  - 사용자 승인 및 참여 상태 변경 요청 시 승인 여부와 변경 사유를 명확하게 전달할 수 있습니다.
  - 기존과 동일한 설정 변경 시 별도의 예외로 안내하며, 중복 변경 방지가 강화되었습니다.

- **버그 수정**
  - 사용자 승인 및 참여 상태 변경 로직의 일관성과 예외 처리가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->